### PR TITLE
feat: use daemonset for machineid instead of docker mount

### DIFF
--- a/manifests/haproxy.yaml
+++ b/manifests/haproxy.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: haproxy-config
-  namespace: metallb-system
 data:
   haproxy.cfg: |
     global
@@ -69,7 +68,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: haproxy
-  namespace: metallb-system
 spec:
   selector:
     matchLabels:

--- a/manifests/machineid.yaml
+++ b/manifests/machineid.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ensure-machine-id
+  labels:
+    app: ensure-machine-id
+spec:
+  selector:
+    matchLabels:
+      name: ensure-machine-id
+  template:
+    metadata:
+      labels:
+        name: ensure-machine-id
+    spec:
+      initContainers:
+        - name: generate-machine-id
+          image: cgr.dev/chainguard/wolfi-base:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - echo "B0D07F1F43F246409516ADBDCCC86FCE" > /mnt/host/etc/machine-id;
+          volumeMounts:
+            - name: machine-id
+              mountPath: /mnt/host/etc
+              readOnly: false
+          securityContext:
+            privileged: true
+            runAsUser: 0
+      containers:
+        - name: pause
+          image: k8s.gcr.io/pause:3.1
+          resources:
+            limits:
+              cpu: "0.1"
+              memory: "50Mi"
+      volumes:
+        - name: machine-id
+          hostPath:
+            path: /etc
+
+      hostPID: true

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -2,7 +2,6 @@ apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
   name: dev
-  namespace: metallb-system
 spec:
   addresses:
     - "###ZARF_VAR_BASE_IP###.200-###ZARF_VAR_BASE_IP###.215"
@@ -11,4 +10,3 @@ apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
   name: empty
-  namespace: metallb-system

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -36,8 +36,6 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: echo "B0D07F1F43F246409516ADBDCCC86FCE" > tmp-machine-id
-            description: "Create a machine-id file for the nodes"
           - cmd: |
               k3d cluster create \
               -p "80:20080@server:*" \
@@ -47,11 +45,8 @@ components:
               --k3s-arg "--disable=metrics-server@server:*" \
               --k3s-arg "--disable=servicelb@server:*" \
               --image ${ZARF_VAR_K3D_IMAGE} \
-              --volume $(pwd)/tmp-machine-id:/etc/machine-id@server:* \
               ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"
-        after:
-          - cmd: rm -f tmp-machine-id
         onSuccess:
           - cmd: |
               echo "You can access this cluster over SSH (note http redirect will redirect to port 80 instead of 8080):"
@@ -59,15 +54,14 @@ components:
               echo
               echo "To get the kubeconfig:"
               echo "k3d kubeconfig get ${ZARF_VAR_CLUSTER_NAME}"
+              echo
+              echo "This cluster can be destroyed with:"
+              echo "k3d cluster delete ${ZARF_VAR_CLUSTER_NAME}"
             description: "Print out information about how to access the cluster remotely"
-      onRemove:
-        before:
-          - cmd: k3d cluster delete ${ZARF_VAR_CLUSTER_NAME}
-            description: "Destroy the cluster"
 
-  - name: loadbalancer-stack
+  - name: uds-dev-stack
     required: true
-    description: "Install MetalLB and HAProxy to provide a load balancer for the cluster"
+    description: "Install MetalLB, HAProxy, and Ensure MachineID to meet UDS developer needs without later config changes"
     actions:
       onDeploy:
         before:
@@ -78,10 +72,12 @@ components:
     charts:
       - name: metallb
         url: https://metallb.github.io/metallb
-        namespace: metallb-system
+        namespace: uds-dev-stack
         version: 0.13.11
     manifests:
-      - name: metallb-config
+      - name: uds-dev-stack
+        namespace: uds-dev-stack
         files:
+          - "manifests/machineid.yaml"
           - "manifests/metallb.yaml"
           - "manifests/haproxy.yaml"


### PR DESCRIPTION
## Description

This replaces the problematic volume mount to generate a machine-id with a initcontainer daemonset to do the same without the janky docker mount issues. Also removed `onRemote` action that would break due to [this](https://github.com/defenseunicorns/zarf/issues/2130) Zarf issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed