### PR TITLE
Correcting the URL in the example Deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This zarf package serves as a universal dev (local & remote) and test environmen
 
 ## Deploy
 
-`zarf package deploy oci://defenseunicorns/uds-k3d:0.2.0`<!-- {x-release-please-version} -->`-multi`
+`zarf package deploy oci://ghcr.io/defenseunicorns/uds-k3d:0.2.0`<!-- {x-release-please-version} -->`-multi`
 
 ## Create
 


### PR DESCRIPTION
The listed URL results in a error:
```
~ zarf package deploy oci://defenseunicorns/packages/uds-k3d:0.2.0-multi

 ERROR:  Failed to deploy package: unable to load the Zarf Package: unable to handle the provided package
             path: Head "https://defenseunicorns/v2/packages/uds-k3d/manifests/0.2.0-multi": dial tcp: lookup
             defenseunicorns: no such host
```