### PR TITLE
chore: update minio chart to use chainguard latest-dev images

### DIFF
--- a/chart/templates/minio-cm.yaml
+++ b/chart/templates/minio-cm.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: entrypoint-script
+  namespace: {{ .Release.Namespace }}
+data:
+  docker-entrypoint.sh: |
+    #!/bin/sh
+    #
+
+    # If command starts with an option, prepend minio.
+    if [ "${1}" != "minio" ]; then
+      if [ -n "${1}" ]; then
+        set -- minio "$@"
+      fi
+    fi
+
+    docker_switch_user() {
+      if [ -n "${MINIO_USERNAME}" ] && [ -n "${MINIO_GROUPNAME}" ]; then
+        if [ -n "${MINIO_UID}" ] && [ -n "${MINIO_GID}" ]; then
+          chroot --userspec=${MINIO_UID}:${MINIO_GID} / "$@"
+        else
+          echo "${MINIO_USERNAME}:x:1000:1000:${MINIO_USERNAME}:/:/sbin/nologin" >>/etc/passwd
+          echo "${MINIO_GROUPNAME}:x:1000" >>/etc/group
+          chroot --userspec=${MINIO_USERNAME}:${MINIO_GROUPNAME} / "$@"
+        fi
+      else
+        exec "$@"
+      fi
+    }
+
+    ## DEPRECATED and unsupported - switch to user if applicable.
+    docker_switch_user "$@"

--- a/values/minio-values.yaml
+++ b/values/minio-values.yaml
@@ -1,6 +1,30 @@
 replicas: 1
 mode: standalone
 
+image:
+  repository: cgr.dev/chainguard/minio
+  tag: latest-dev
+
+mcImage:
+  repository: cgr.dev/chainguard/minio-client
+  tag: latest-dev
+
+## Additional volumes to minio container
+extraVolumes:   
+  - name: entrypoint-script-volume
+    configMap:
+      name: entrypoint-script
+      defaultMode: 0777  
+
+## Additional volumeMounts to minio container
+extraVolumeMounts: 
+  - name: entrypoint-script-volume
+    mountPath: /usr/bin/docker-entrypoint.sh
+    subPath: docker-entrypoint.sh
+    
+
+
+
 # Some reasonable requests instead of the bonkers defaults
 resources:
   requests:


### PR DESCRIPTION
## Description

update minio chart to use chainguard latest-dev images for minio.
...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed