### PR TITLE
feat: internal uds.dev resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build/
 zarf-sbom
 tmp/
 zarf-config.yaml
-core-dns-custom.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 zarf-sbom
 tmp/
 zarf-config.yaml
+core-dns-custom.yaml

--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ package:
 Configure MinIO:
 
 - [Configuring Minio](docs/MINIO.md)
+
+### DNS Assumptions:
+
+- [DNS Assumptions](docs/DNS.md)

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  uds.override: |
+    rewrite name regex (.*\.uds\.dev) host.k3d.internal

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -1,0 +1,13 @@
+## Domain Assumptions
+
+One of the core assumptions of the `uds-k3d` package is the use of `uds.dev` as the base domain for your development environment. This assumption is integral to the DNS and network configuration provided by the package. It is based on an existing DNS entry for `*.uds.dev` that resolves to `127.0.0.1`, facilitating local development and testing.
+
+### CoreDNS Override
+
+The package includes a CoreDNS configuration override designed to rewrite requests for `*.uds.dev` to `host.k3d.internal`. This rewrite ensures that any DNS resolution request within the cluster targeting a `*.uds.dev` address will be correctly routed to `host.k3d.internal` which is an internal K3D alias which resolves to the host gateway. 
+
+The outcome of this is a pods in the cluster can resolve domains like sso.uds.dev to an address (not 127.0.0.1) that will ultimately get routed correctly.
+
+### Nginx Configuration
+
+Additionally, the package includes Nginx configuration that assumes the use of `uds.dev` as the base domain. This configuration is tailored to support the development environment setup, ensuring that Nginx correctly handles requests and routes them within the cluster, based on the `uds.dev` domain.

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -39,6 +39,7 @@ components:
     actions:
       onDeploy:
         before:
+          - cmd: kubectl create configmap coredns-custom --namespace=kube-system --from-literal=uds.override='rewrite name regex (.*\.uds\.dev) host.k3d.internal' --dry-run=client -o yaml > core-dns-custom.yaml
           - cmd: |
               k3d cluster create \
               -p "80:20080@server:*" \
@@ -48,6 +49,8 @@ components:
               --k3s-arg "--disable=metrics-server@server:*" \
               --k3s-arg "--disable=servicelb@server:*" \
               --k3s-arg "--disable=local-storage@server:*" \
+              --k3s-arg "--disable=servicelb@server:*" \
+              --volume ${PWD}/core-dns-custom.yaml:/var/lib/rancher/k3s/server/manifests/dns-custom.yaml \
               --image ${ZARF_VAR_K3D_IMAGE} ${ZARF_VAR_K3D_EXTRA_ARGS} \
               ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -49,7 +49,6 @@ components:
               --k3s-arg "--disable=metrics-server@server:*" \
               --k3s-arg "--disable=servicelb@server:*" \
               --k3s-arg "--disable=local-storage@server:*" \
-              --k3s-arg "--disable=servicelb@server:*" \
               --volume ${PWD}/core-dns-custom.yaml:/var/lib/rancher/k3s/server/manifests/dns-custom.yaml \
               --image ${ZARF_VAR_K3D_IMAGE} ${ZARF_VAR_K3D_EXTRA_ARGS} \
               ${ZARF_VAR_CLUSTER_NAME}

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -39,7 +39,6 @@ components:
     actions:
       onDeploy:
         before:
-          - cmd: kubectl create configmap coredns-custom --namespace=kube-system --from-literal=uds.override='rewrite name regex (.*\.uds\.dev) host.k3d.internal' --dry-run=client -o yaml > core-dns-custom.yaml
           - cmd: |
               k3d cluster create \
               -p "80:20080@server:*" \
@@ -49,7 +48,6 @@ components:
               --k3s-arg "--disable=metrics-server@server:*" \
               --k3s-arg "--disable=servicelb@server:*" \
               --k3s-arg "--disable=local-storage@server:*" \
-              --volume ${PWD}/core-dns-custom.yaml:/var/lib/rancher/k3s/server/manifests/dns-custom.yaml \
               --image ${ZARF_VAR_K3D_IMAGE} ${ZARF_VAR_K3D_EXTRA_ARGS} \
               ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"
@@ -75,6 +73,9 @@ components:
             description: "Load network ip base for MetalLB"
             setVariables:
               - name: BASE_IP
+        after:
+          - cmd: ./zarf tools kubectl rollout restart deployment coredns -n kube-system
+            description: "Restart CoreDNS to pick up internal DNS override for uds.dev"
     charts:
       - name: metallb
         namespace: uds-dev-stack


### PR DESCRIPTION
## Description
Adds a coredns rewrite rule to point `*.uds.dev` to `host.k3d.internal` 

## Related Issue
Fixes https://github.com/defenseunicorns/uds-k3d/issues/45


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed