### PR TITLE
ci: pin to specific k3d version & add renovate mgmt

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,8 @@ jobs:
           # renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=semver
           version: v0.32.4
 
-      - run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+      # renovate: datasource=github-tags depName=k3d-io/k3d versioning=semver
+      - run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.0 bash"
         shell: bash
 
       - name: Create Zarf Package

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This zarf package serves as a universal dev (local & remote) and test environmen
 
 ## Prerequisites
 
-- [Zarf](https://docs.zarf.dev/docs/getting-started#installing-zarf) v0.31.0 or later
-- [K3d](https://k3d.io/#installation) v5 or later
+- [Zarf](https://docs.zarf.dev/docs/getting-started#installing-zarf) version: 0.31.0
+- [K3d](https://k3d.io/#installation) version: 5.4.6
 - [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/getting-started/installation) for running K3d
 
 ## Deploy

--- a/renovate.json
+++ b/renovate.json
@@ -49,14 +49,33 @@
       "datasourceTemplate": "helm"
     },
     {
-      "description": "Match on comments for zarf github actions in yaml files.",
+      "description": "Match on comments for zarf and k3d github actions in yaml files.",
       "fileMatch": ["./.+\\.ya?ml$"],
       "matchStrings": [
         "# renovate: datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?version:\\s*(?<currentValue>.*)\\s",
-        "# renovate: datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?version:\\s*['\"](?<currentValue>.*)['\"]\\s"
+        "# renovate: datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?version:\\s*['\"](?<currentValue>.*)['\"]\\s",
+        "# renovate: datasource=github-tags depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*\\sTAG=(?<currentValue>.*)\\sbash.*"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
       "datasourceTemplate": "github-tags"
+    },
+    {
+      "depNameTemplate": "defenseunicorns/zarf",
+      "fileMatch": ["README\\.md"],
+      "matchStrings": [
+        "\\[Zarf\\].*\\sversion:[\\s]*(?<currentValue>v?\\d*[^\\s]?\\d*[^\\s]\\d*)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "depNameTemplate": "k3d-io/k3d",
+      "fileMatch": ["README\\.md"],
+      "matchStrings": [
+        "\\[K3d\\].*\\sversion:[\\s]*(?<currentValue>v?\\d*[^\\s]?\\d*[^\\s]\\d*)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Description

Pin K3d to a specific TAG version for github workflow and add corresponding renovate configuration

## Related Issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed