### PR TITLE
fix: broken validate task

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Setup UDS
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/setup@v0.4.0
+        uses: defenseunicorns/uds-common/.github/actions/setup@b604d2e1b3fc69f29122f9a709c605f5ecf4da18
         with:
           username: ${{secrets.IRON_BANK_ROBOT_USERNAME}}
           password: ${{secrets.IRON_BANK_ROBOT_PASSWORD}}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Setup UDS
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/setup@v0.3.6
+        uses: defenseunicorns/uds-common/.github/actions/setup@v0.4.0
         with:
           username: ${{secrets.IRON_BANK_ROBOT_USERNAME}}
           password: ${{secrets.IRON_BANK_ROBOT_PASSWORD}}

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -37,8 +37,7 @@ tasks:
         cmd: |
           set -e
           # uds zarf tools download-init does not work in 0.9.4 - https://github.com/defenseunicorns/uds-cli/issues/517
-          uds zarf package pull oci://ghcr.io/defenseunicorns/packages/init:v$(uds zarf version)
-          mv zarf-init-amd64-v$(uds zarf version).tar.zst zarf-init-amd64-$(uds zarf version).tar.zst
+          uds zarf package pull oci://ghcr.io/defenseunicorns/packages/init:$(uds zarf version)
           # Test zarf init due to containerd issue - https://github.com/defenseunicorns/zarf/issues/592
           uds zarf init --confirm
 


### PR DESCRIPTION
## Description
Removed redundant v in init tag in validate task.
Task was also trying to mv the zarf file to itself.
...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed