### PR TITLE
chore: update to latest k3s patches, switch port mapping to standard ports

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,11 +17,7 @@ jobs:
     strategy:
       matrix:
         image: ["ghcr.io/defenseunicorns/oss/uds-k3d-k3s"]
-        version: ["v1.27.11-k3s1", "v1.28.7-k3s1", "v1.29.2-k3s1"]
-        # Test the default image as well
-        include:
-          - image: "rancher/k3s"
-            version: "v1.27.4-k3s1"
+        version: ["v1.27.13-k3s1", "v1.28.9-k3s1", "v1.29.4-k3s1"]
 
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,10 +31,10 @@ jobs:
 
       - name: Build the custom k3s image
         if: ${{matrix.image}} != "rancher/k3s"
-        run: uds run build-image --set VERSION=${{matrix.version}}
+        run: uds run build-image --set VERSION=${{matrix.version}} --no-progress
 
       - name: Create and deploy the uds-k3d package
-        run: uds run --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}}
+        run: uds run --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
 
       - name: Validate uds-k3d package
-        run: uds run validate
+        run: uds run validate --no-progress

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -39,4 +39,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish the custom k3s image
-        run: uds run publish-image --set VERSION=${{matrix.version}}
+        run: uds run publish-image --set VERSION=${{matrix.version}} --no-progress

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v1.27.11-k3s1", "v1.28.7-k3s1", "v1.29.2-k3s1"]
+        version: ["v1.27.13-k3s1", "v1.28.9-k3s1", "v1.29.4-k3s1"]
 
     permissions:
       contents: read

--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -71,9 +71,9 @@ spec:
           command: ["nginx", "-g", "daemon off;"]
           ports:
             - containerPort: 80
-              hostPort: 20080
+              hostPort: 80
             - containerPort: 443
-              hostPort: 20443
+              hostPort: 443
           volumeMounts:
             - name: config-volume
               mountPath: /etc/nginx/nginx.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG K3S_TAG="v1.28.7-k3s1"
+ARG K3S_TAG="v1.28.9-k3s1"
 
 FROM rancher/k3s:$K3S_TAG as k3s
 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,18 +1,20 @@
 variables:
   - name: VERSION
-    default: "v1.28.7-k3s1"
+    default: "v1.28.9-k3s1"
   - name: IMAGE_NAME
     default: "ghcr.io/defenseunicorns/oss/uds-k3d-k3s"
+  - name: K3D_EXTRA_ARGS
+    default: ""
 
 tasks:
   - name: default
     description: "Build and deploy uds-k3d"
     actions:
       - description: "Build UDS K3d package"
-        cmd: "uds zarf package create --confirm"
+        cmd: "uds zarf package create --confirm --no-progress"
 
       - description: "Deploy UDS K3d package"
-        cmd: "uds zarf package deploy zarf-package-uds-k3d-*.tar.zst --confirm --set K3D_IMAGE=${IMAGE_NAME}:${VERSION}"
+        cmd: "uds zarf package deploy zarf-package-uds-k3d-*.tar.zst --confirm --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} --set K3D_EXTRA_ARGS=\"${K3D_EXTRA_ARGS}\" --no-progress"
 
   - name: validate
     actions:
@@ -36,10 +38,9 @@ tasks:
       - description: Validate zarf init
         cmd: |
           set -e
-          # uds zarf tools download-init does not work in 0.9.4 - https://github.com/defenseunicorns/uds-cli/issues/517
-          uds zarf package pull oci://ghcr.io/defenseunicorns/packages/init:$(uds zarf version)
+          uds zarf tools download-init --no-progress
           # Test zarf init due to containerd issue - https://github.com/defenseunicorns/zarf/issues/592
-          uds zarf init --confirm
+          uds zarf init --confirm --no-progress
 
   - name: build-image
     actions:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    default: "rancher/k3s:v1.27.4-k3s1"
+    default: "ghcr.io/defenseunicorns/oss/uds-k3d-k3s:v1.28.9-k3s1"
 
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"
@@ -41,8 +41,8 @@ components:
         before:
           - cmd: |
               k3d cluster create \
-              -p "80:20080@server:*" \
-              -p "443:20443@server:*" \
+              -p "80:80@server:*" \
+              -p "443:443@server:*" \
               --api-port 6550 \
               --k3s-arg "--disable=traefik@server:*" \
               --k3s-arg "--disable=metrics-server@server:*" \


### PR DESCRIPTION
## Description

Changes:
- Updated to latest patch releases for our custom k3s image (this should be short-lived since the zarf issue is resolved pending a release🤞)
- Adds `--no-progress` to tasks (uds/maru task output fix)
- Switches hostports for nginx 20443/20080 -> 443/80:
  - This allows calls from the nodes destined for `uds.dev` addresses to resolve properly
  - In particular this is beneficial for kube apiserver OIDC setup, when tying to keycloak in the cluster
  - No adverse effects observed with this change (no extra privileges needed, all VS resolved as expected still)
  - Also note that the "external" docker port binding hasn't changed, this was always 443/80

## Related Issue

Fixes https://github.com/defenseunicorns/uds-k3d/issues/75

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed