### PR TITLE
chore(docs): graceful k3d shutdown and startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ This package is published via CI, but can be created locally with the following 
 
 `k3d cluster delete uds` (uds is the default cluster name).
 
+## Start and Stop
+
+To turn stop and start an existing UDS K3d cluster gracefully without disrupting the `host.k3d.internal` CoreDNS rewrite for `*.uds.dev`, use the following to start and stop the cluster before machine hibernation, suspension, restart, or shutoff:
+
+```bash
+# to stop the default UDS cluster
+k3d cluster stop uds
+
+# to start the default UDS cluster
+k3d cluster start uds
+```
+
 ## Additional Info
 
 You can set extra k3d args by setting the deploy-time ZARF_VAR_K3D_EXTRA_ARGS. See below `zarf-config.yaml` example k3d args:
@@ -50,10 +62,10 @@ package:
       k3d_extra_args: "--k3s-arg --gpus=1 --k3s-arg --<arg2>=<value>"
 ```
 
-Configure MinIO:
+### Configure MinIO
 
 - [Configuring Minio](docs/MINIO.md)
 
-### DNS Assumptions:
+### DNS Assumptions
 
 - [DNS Assumptions](docs/DNS.md)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This package is published via CI, but can be created locally with the following 
 
 ## Start and Stop
 
-To turn stop and start an existing UDS K3d cluster gracefully without disrupting the `host.k3d.internal` CoreDNS rewrite for `*.uds.dev`, use the following to start and stop the cluster before machine hibernation, suspension, restart, or shutoff:
+To stop and start an existing UDS K3d cluster gracefully, without disrupting the `host.k3d.internal` CoreDNS rewrite for `*.uds.dev`, use the following to start and stop the cluster before machine hibernation, suspension, restart, or shutoff:
 
 ```bash
 # to stop the default UDS cluster

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This package is published via CI, but can be created locally with the following 
 
 ## Start and Stop
 
-To stop and start an existing UDS K3d cluster gracefully, without disrupting the `host.k3d.internal` CoreDNS rewrite for `*.uds.dev`, use the following to start and stop the cluster before machine hibernation, suspension, restart, or shutoff:
+To stop and start an existing UDS K3d cluster gracefully, without disrupting the `host.k3d.internal` CoreDNS rewrite for `*.uds.dev`, use the following prior to host hibernation, suspension, restart, or shutoff:
 
 ```bash
 # to stop the default UDS cluster


### PR DESCRIPTION
## Description

Adds documentation for gracefully starting and stopping the K3d cluster to avoid `host.k3d.internal` resolution going stale upon Docker or Machine suspension, hibernation, shutdown, or restarts.

See the related issue below for more details. A recommended technical fix is provided within the issue, in case documentation is not sufficient enough for the end user.

## Related Issue

Fixes #99 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md)(https://github.com/defenseunicorns/uds-template-capability/blob/main/CONTRIBUTING.md#submitting-a-pull-request) followed