### PR TITLE
chore: update k3s test versions, default to 1.30.4

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         image: ["rancher/k3s"]
-        version: ["v1.28.11-k3s2", "v1.29.6-k3s2", "v1.30.2-k3s2"]
+        version: ["v1.29.8-k3s1", "v1.30.4-k3s1", "v1.31.0-k3s1"]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v1.28.11-k3s2", "v1.29.6-k3s2", "v1.30.2-k3s2"]
+        version: ["v1.2.3-k3s1"] # Placeholder
 
     permissions:
       contents: read

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG K3S_TAG="v1.29.6-k3s2"
+ARG K3S_TAG="v1.2.3-k3s1" # Placeholder
 
 FROM rancher/k3s:$K3S_TAG as k3s
 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,6 +1,6 @@
 variables:
   - name: VERSION
-    default: "v1.29.6-k3s2"
+    default: "v1.30.4-k3s1"
   - name: IMAGE_NAME
     default: "rancher/k3s"
   - name: K3D_EXTRA_ARGS

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    default: "rancher/k3s:v1.29.6-k3s2"
+    default: "rancher/k3s:v1.30.4-k3s1"
 
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"


### PR DESCRIPTION
## Description

Updates default k3s version to 1.30.4 (n-1 minor k8s version). Also updates testing matrix to 1.29, 1.30, 1.31 (latest patch versions).

Also removed/modified the placeholder versions in unused image build workflow/dockerfile.