### PR TITLE
chore: allow volumeexpansion in localpath storageclass

### DIFF
--- a/chart/templates/localpath-rwx.yaml
+++ b/chart/templates/localpath-rwx.yaml
@@ -87,6 +87,7 @@ metadata:
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
+allowVolumeExpansion: true
 
 ---
 kind: ConfigMap


### PR DESCRIPTION
## Description

Changes to support volume expansion to allow more things with uds-k3d, see upstream defaults: https://github.com/rancher/local-path-provisioner/blob/7a64e376245fcfd57d5d8a9ba6ab04f10f39f68e/deploy/chart/local-path-provisioner/templates/storageclass.yaml#L22

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed