### PR TITLE
feat: implement graceful, modifiable UDS Core CoreDNS overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This package is published via CI, but can be created locally with the following 
 
 ## Start and Stop
 
-To stop and start an existing UDS K3d cluster gracefully, without disrupting the `host.k3d.internal` CoreDNS rewrite for `*.uds.dev`, use the following prior to host hibernation, suspension, restart, or shutoff:
+To stop and start an existing UDS K3d cluster gracefully, use the following prior to host hibernation, suspension, restart, or shutoff:
 
 ```bash
 # to stop the default UDS cluster

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,4 +15,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+# x-release-please-start-version
+version: 0.9.0
+# x-release-please-end

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,5 +5,12 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
-{{ .Values.coreDnsDefaults | nindent 4 }}
-{{ .Values.coreDnsOverrides | nindent 4 }}
+    rewrite stop {
+      name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+    }
+    rewrite stop {
+      name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
+    }
+    rewrite stop {
+      name regex (.*\.uds\.dev) host.k3d.internal answer auto
+    }

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
-{{ .Values.coreDnsDefaults | nindent 4 }}
 {{ .Values.coreDnsOverrides | nindent 4 }}

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,12 +5,4 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
-    rewrite stop {
-      name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
-    }
-    rewrite stop {
-      name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
-    }
-    rewrite stop {
-      name regex (.*\.uds\.dev) host.k3d.internal answer auto
-    }
+{{ .Values.coreDnsOverrides | indent 4 }}

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,12 +5,4 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
-    {{- if .Values.coreDnsOverrides }}
-    {{- if kindIs "string" .Values.coreDnsOverrides }}
-    {{ .Values.coreDnsOverrides | indent 4 }}
-    {{- else if kindIs "array" .Values.coreDnsOverrides }}
-    {{- range .Values.coreDnsOverrides }}
-    {{ . | indent 4 }}
-    {{- end }}
-    {{- end }}
-    {{- end }}
+{{ .Values.coreDnsOverrides | indent 4 }}

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,9 +5,12 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
-    rewrite {
-      name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
-    }
-    rewrite {
-      name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
-    }
+    {{- if .Values.coreDnsOverrides }}
+    {{- if kindIs "string" .Values.coreDnsOverrides }}
+    {{ .Values.coreDnsOverrides | indent 4 }}
+    {{- else if kindIs "array" .Values.coreDnsOverrides }}
+    {{- range .Values.coreDnsOverrides }}
+    {{ . | indent 4 }}
+    {{- end }}
+    {{- end }}
+    {{- end }}

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
-{{ .Values.coreDnsOverrides | indent 4 }}
+{{ .Values.coreDnsDefaults | nindent 4 }}
+{{ .Values.coreDnsOverrides | nindent 4 }}

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
+{{ .Values.coreDnsDefaults | nindent 4 }}
 {{ .Values.coreDnsOverrides | nindent 4 }}

--- a/chart/templates/core-dns-custom.yaml
+++ b/chart/templates/core-dns-custom.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: kube-system
 data:
   uds.override: |
-    rewrite stop {
-      name regex (.*\.uds\.dev) host.k3d.internal answer auto
+    rewrite {
+      name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+    }
+    rewrite {
+      name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
     }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,1 +1,12 @@
 extraPorts: []
+
+coreDnsOverrides: |
+  rewrite stop {
+    name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+  }
+  rewrite stop {
+    name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
+  }
+  rewrite stop {
+    name regex (.*\.uds\.dev) host.k3d.internal answer auto
+  }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,11 +1,9 @@
 extraPorts: []
 
-coreDnsDefaults: |
+coreDnsOverrides: |
   rewrite {
     name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
   }
   rewrite {
     name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
   }
-
-coreDnsOverrides: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,11 +1,1 @@
 extraPorts: []
-
-coreDnsDefaults: |
-  rewrite {
-    name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
-  }
-  rewrite {
-    name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
-  }
-
-coreDnsOverrides: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,11 +1,9 @@
 extraPorts: []
 
-coreDnsOverrides:
-  - |
-    rewrite {
-      name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
-    }
-  - |
-    rewrite {
-      name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
-    }
+coreDnsOverrides: |
+  rewrite {
+    name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+  }
+  rewrite {
+    name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
+  }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,6 +7,3 @@ coreDnsOverrides: |
   rewrite stop {
     name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
   }
-  rewrite stop {
-    name regex (.*\.uds\.dev) host.k3d.internal answer auto
-  }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,7 +2,7 @@ extraPorts: []
 
 coreDnsOverrides: |
   rewrite {
-    name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+    name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
   }
   rewrite {
     name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,9 +1,11 @@
 extraPorts: []
 
-coreDnsOverrides: |
+coreDnsDefaults: |
   rewrite {
     name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
   }
   rewrite {
     name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
   }
+
+coreDnsOverrides: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,1 +1,11 @@
 extraPorts: []
+
+coreDnsOverrides:
+  - |
+    rewrite {
+      name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+    }
+  - |
+    rewrite {
+      name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
+    }

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -6,19 +6,9 @@ One of the core assumptions of the `uds-k3d` package is the use of `uds.dev` as 
 
 [UDS Core](https://github.com/defenseunicorns/uds-core) is assumed to be the main infrastructure and/or testing target in local development; therefore, the DNS resolution assumes the existence of the default admin and tenant Istio gateways.
 
-This package includes a CoreDNS configuration override designed to rewrite requests for `*.uds.dev` to the tenant and admin Istio gateways based on the subdomain, `*.admin.uds.dev` or `*.uds.dev`. This rewrite ensures that any DNS resolution request within the cluster targeting a `*.uds.dev` address will be correctly routed to the correct service mesh gateway.
+This package includes a CoreDNS configuration override designed to rewrite requests for `*.uds.dev` to the tenant and admin Istio gateways based on the subdomain, `*.admin.uds.dev` or `*.uds.dev`. This rewrite ensures that any DNS resolution request within the cluster targeting a `*.uds.dev` address will be correctly routed to the correct service mesh gateway. A final rewrite in this package is used as a catch-all by redirecting `*.uds.dev` requests to `host.k3d.internal`.
 
 The outcome of this is a pods in the cluster can resolve domains like sso.uds.dev to an address (not 127.0.0.1) that will ultimately get routed correctly.
-
-To add additional CoreDNS overrides, you can set the `coreDnsOverrides` value by supplying the following to the deployment command:
-
-```bash
---set COREDNS_OVERRIDES="
-rewrite {
-  name regex (.*\.uds\.dev) host.k3d.internal answer auto
-}
-"
-```
 
 ## Nginx Configuration
 

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -10,6 +10,21 @@ This package includes a CoreDNS configuration override designed to rewrite reque
 
 The outcome of this is a pods in the cluster can resolve domains like sso.uds.dev to an address (not 127.0.0.1) that will ultimately get routed correctly.
 
+You can use Zarf Helm overrides to overwrite the overrides provided by default in this package. To do so you must have Zarf >= v0.33.0. An example of how one might use this override with the default UDS task is as follows:
+
+```bash
+# Define the overrides
+COREDNS_OVERRIDES=$(cat << 'EOF'
+rewrite stop {
+  name regex (.*\.uds\.dev) host.k3d.internal answer auto
+}
+EOF
+)
+
+# Now use the variable in your command
+uds run --set COREDNS_OVERRIDES="$COREDNS_OVERRIDES"
+```
+
 ## Nginx Configuration
 
 Additionally, the package includes Nginx configuration that assumes the use of `uds.dev` as the base domain. This configuration is tailored to support the development environment setup, ensuring that Nginx correctly handles requests and routes them within the cluster, based on the `uds.dev` domain.

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -13,7 +13,8 @@ The outcome of this is a pods in the cluster can resolve domains like sso.uds.de
 To add additional CoreDNS overrides, you can set the `coreDnsOverrides` value by supplying the following to the deployment command:
 
 ```bash
---set COREDNS_OVERRIDES="rewrite {
+--set COREDNS_OVERRIDES="
+rewrite {
   name regex (.*\.uds\.dev) host.k3d.internal answer auto
 }
 "

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -4,7 +4,9 @@ One of the core assumptions of the `uds-k3d` package is the use of `uds.dev` as 
 
 ### CoreDNS Override
 
-The package includes a CoreDNS configuration override designed to rewrite requests for `*.uds.dev` to `host.k3d.internal`. This rewrite ensures that any DNS resolution request within the cluster targeting a `*.uds.dev` address will be correctly routed to `host.k3d.internal` which is an internal K3D alias which resolves to the host gateway. 
+[UDS Core](https://github.com/defenseunicorns/uds-core) is assumed to be the main infrastructure and/or testing target in local development; therefore, the DNS resolution assumes the existence of the default admin and tenant Istio gateways.
+
+This package includes a CoreDNS configuration override designed to rewrite requests for `*.uds.dev` to the tenant and admin Istio gateways based on the subdomain, `*.admin.uds.dev` or `*.uds.dev`. This rewrite ensures that any DNS resolution request within the cluster targeting a `*.uds.dev` address will be correctly routed to the correct service mesh gateway.
 
 The outcome of this is a pods in the cluster can resolve domains like sso.uds.dev to an address (not 127.0.0.1) that will ultimately get routed correctly.
 

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -10,6 +10,15 @@ This package includes a CoreDNS configuration override designed to rewrite reque
 
 The outcome of this is a pods in the cluster can resolve domains like sso.uds.dev to an address (not 127.0.0.1) that will ultimately get routed correctly.
 
+To add additional CoreDNS overrides, you can set the `coreDnsOverrides` value by supplying the following to the deployment command:
+
+```bash
+--set COREDNS_OVERRIDES="rewrite {
+  name regex (.*\.uds\.dev) host.k3d.internal answer auto
+}
+"
+```
+
 ## Nginx Configuration
 
 Additionally, the package includes Nginx configuration that assumes the use of `uds.dev` as the base domain. This configuration is tailored to support the development environment setup, ensuring that Nginx correctly handles requests and routes them within the cluster, based on the `uds.dev` domain.

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -1,8 +1,8 @@
-## Domain Assumptions
+# Domain Assumptions
 
 One of the core assumptions of the `uds-k3d` package is the use of `uds.dev` as the base domain for your development environment. This assumption is integral to the DNS and network configuration provided by the package. It is based on an existing DNS entry for `*.uds.dev` that resolves to `127.0.0.1`, facilitating local development and testing.
 
-### CoreDNS Override
+## CoreDNS Override
 
 [UDS Core](https://github.com/defenseunicorns/uds-core) is assumed to be the main infrastructure and/or testing target in local development; therefore, the DNS resolution assumes the existence of the default admin and tenant Istio gateways.
 
@@ -10,6 +10,6 @@ This package includes a CoreDNS configuration override designed to rewrite reque
 
 The outcome of this is a pods in the cluster can resolve domains like sso.uds.dev to an address (not 127.0.0.1) that will ultimately get routed correctly.
 
-### Nginx Configuration
+## Nginx Configuration
 
 Additionally, the package includes Nginx configuration that assumes the use of `uds.dev` as the base domain. This configuration is tailored to support the development environment setup, ensuring that Nginx correctly handles requests and routes them within the cluster, based on the `uds.dev` domain.

--- a/docs/PORTS.md
+++ b/docs/PORTS.md
@@ -1,20 +1,20 @@
-## Port Configuration
+# Port Configuration
 
 By default, `uds-k3d` will only expose ports `80` and `443` through `k3d` with a redirect from `80` to `443` within the Nginx configuration. The works for most packages however some may require additional TCP ports to be opened in order to provide / test all of their functionality.  To do so you can override the following:
 
-### K3d Override
+## K3d Override
 
 First set (or add to) `K3D_EXTRA_ARGS` to include all of the ports that you would like to expose:
 
-```
+```bash
 --set K3D_EXTRA_ARGS="-p <port>:<port>@server:* -p 9999:9999@server:*"
 ```
 
-### Nginx Configuration
+## Nginx Configuration
 
 Then allow the ports to pass through Nginx by setting `NGINX_EXTRA_PORTS`:
 
-```
+```bash
 --set NGINX_EXTRA_PORTS="[<port>,9999]"
 ```
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
         { "type": "chore", "section": "Miscellaneous", "hidden": false }
       ],
       "versioning": "default",
-      "extra-files": ["README.md", "zarf.yaml"]
+      "extra-files": ["README.md", "zarf.yaml", "chart/Chart.yaml"]
     }
   }
 }

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -7,6 +7,9 @@ variables:
     default: ""
   - name: NGINX_EXTRA_PORTS
     default: "[]"
+  - name: COREDNS_OVERRIDES
+    autoIndent: true
+    default: ""
 
 tasks:
   - name: default
@@ -21,6 +24,7 @@ tasks:
             --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} \
             --set K3D_EXTRA_ARGS="${K3D_EXTRA_ARGS}" \
             --set NGINX_EXTRA_PORTS="${NGINX_EXTRA_PORTS}" \
+            --set COREDNS_OVERRIDES="${COREDNS_OVERRIDES}" \
             --no-progress --confirm
 
   - name: validate

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -7,6 +7,17 @@ variables:
     default: ""
   - name: NGINX_EXTRA_PORTS
     default: "[]"
+  - name: COREDNS_OVERRIDES
+    default: |
+      rewrite stop {
+        name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+      }
+      rewrite stop {
+        name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
+      }
+      rewrite stop {
+        name regex (.*\.uds\.dev) host.k3d.internal answer auto
+      }
 
 tasks:
   - name: default
@@ -21,6 +32,7 @@ tasks:
             --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} \
             --set K3D_EXTRA_ARGS="${K3D_EXTRA_ARGS}" \
             --set NGINX_EXTRA_PORTS="${NGINX_EXTRA_PORTS}" \
+            --set COREDNS_OVERRIDES="${COREDNS_OVERRIDES}" \
             --no-progress --confirm
 
   - name: validate

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -7,14 +7,6 @@ variables:
     default: ""
   - name: NGINX_EXTRA_PORTS
     default: "[]"
-  - name: COREDNS_OVERRIDES
-    default: |
-      rewrite {
-        name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
-      }
-      rewrite {
-        name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
-      }
 
 tasks:
   - name: default
@@ -29,7 +21,6 @@ tasks:
             --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} \
             --set K3D_EXTRA_ARGS="${K3D_EXTRA_ARGS}" \
             --set NGINX_EXTRA_PORTS="${NGINX_EXTRA_PORTS}" \
-            --set COREDNS_OVERRIDES="${COREDNS_OVERRIDES}" \
             --no-progress --confirm
 
   - name: validate

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -15,9 +15,6 @@ variables:
       rewrite stop {
         name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
       }
-      rewrite stop {
-        name regex (.*\.uds\.dev) host.k3d.internal answer auto
-      }
 
 tasks:
   - name: default

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -7,9 +7,6 @@ variables:
     default: ""
   - name: NGINX_EXTRA_PORTS
     default: "[]"
-  - name: COREDNS_OVERRIDES
-    autoIndent: true
-    default: ""
 
 tasks:
   - name: default
@@ -24,7 +21,6 @@ tasks:
             --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} \
             --set K3D_EXTRA_ARGS="${K3D_EXTRA_ARGS}" \
             --set NGINX_EXTRA_PORTS="${NGINX_EXTRA_PORTS}" \
-            --set COREDNS_OVERRIDES="${COREDNS_OVERRIDES}" \
             --no-progress --confirm
 
   - name: validate

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -7,14 +7,6 @@ variables:
     default: ""
   - name: NGINX_EXTRA_PORTS
     default: "[]"
-  - name: COREDNS_OVERRIDES
-    default: |
-      rewrite stop {
-        name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
-      }
-      rewrite stop {
-        name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
-      }
 
 tasks:
   - name: default
@@ -29,7 +21,6 @@ tasks:
             --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} \
             --set K3D_EXTRA_ARGS="${K3D_EXTRA_ARGS}" \
             --set NGINX_EXTRA_PORTS="${NGINX_EXTRA_PORTS}" \
-            --set COREDNS_OVERRIDES="${COREDNS_OVERRIDES}" \
             --no-progress --confirm
 
   - name: validate

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -7,6 +7,14 @@ variables:
     default: ""
   - name: NGINX_EXTRA_PORTS
     default: "[]"
+  - name: COREDNS_OVERRIDES
+    default: |
+      rewrite {
+        name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+      }
+      rewrite {
+        name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
+      }
 
 tasks:
   - name: default
@@ -16,7 +24,13 @@ tasks:
         cmd: "uds zarf package create --confirm --no-progress"
 
       - description: "Deploy UDS K3d package"
-        cmd: "uds zarf package deploy zarf-package-uds-k3d-*.tar.zst --confirm --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} --set K3D_EXTRA_ARGS=\"${K3D_EXTRA_ARGS}\" --set NGINX_EXTRA_PORTS=\"${NGINX_EXTRA_PORTS}\" --no-progress"
+        cmd: |
+          uds zarf package deploy zarf-package-uds-k3d-*.tar.zst \
+            --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} \
+            --set K3D_EXTRA_ARGS="${K3D_EXTRA_ARGS}" \
+            --set NGINX_EXTRA_PORTS="${NGINX_EXTRA_PORTS}" \
+            --set COREDNS_OVERRIDES="${COREDNS_OVERRIDES}" \
+            --no-progress --confirm
 
   - name: validate
     actions:

--- a/values/dev-stack-values.yaml
+++ b/values/dev-stack-values.yaml
@@ -1,4 +1,1 @@
 extraPorts: ###ZARF_VAR_NGINX_EXTRA_PORTS###
-
-coreDnsDefaults: |
-  ###ZARF_VAR_COREDNS_DEFAULTS###

--- a/values/dev-stack-values.yaml
+++ b/values/dev-stack-values.yaml
@@ -1,4 +1,1 @@
 extraPorts: ###ZARF_VAR_NGINX_EXTRA_PORTS###
-
-coreDnsOverrides: |
-  ###ZARF_VAR_COREDNS_OVERRIDES###

--- a/values/dev-stack-values.yaml
+++ b/values/dev-stack-values.yaml
@@ -1,1 +1,4 @@
 extraPorts: ###ZARF_VAR_NGINX_EXTRA_PORTS###
+
+coreDnsOverrides: |
+  ###ZARF_VAR_COREDNS_OVERRIDES###

--- a/values/dev-stack-values.yaml
+++ b/values/dev-stack-values.yaml
@@ -1,3 +1,4 @@
 extraPorts: ###ZARF_VAR_NGINX_EXTRA_PORTS###
 
-coreDnsOverrides: ###ZARF_VAR_COREDNS_OVERRIDES###
+coreDnsOverrides: |
+  ###ZARF_VAR_COREDNS_OVERRIDES###

--- a/values/dev-stack-values.yaml
+++ b/values/dev-stack-values.yaml
@@ -1,4 +1,3 @@
 extraPorts: ###ZARF_VAR_NGINX_EXTRA_PORTS###
 
-coreDnsOverrides: |
-  ###ZARF_VAR_COREDNS_OVERRIDES###
+coreDnsOverrides: ###ZARF_VAR_COREDNS_OVERRIDES###

--- a/values/dev-stack-values.yaml
+++ b/values/dev-stack-values.yaml
@@ -1,4 +1,4 @@
 extraPorts: ###ZARF_VAR_NGINX_EXTRA_PORTS###
 
-coreDnsOverrides: |
-  ###ZARF_VAR_COREDNS_OVERRIDES###
+coreDnsDefaults: |
+  ###ZARF_VAR_COREDNS_DEFAULTS###

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -27,18 +27,6 @@ variables:
     description: "Optionally allow more ports through Nginx (combine with K3D_EXTRA_ARGS '-p <port>:<port>@server:*')"
     default: "[]"
 
-  - name: COREDNS_DEFAULTS
-    description: |
-      "Default CoreDNS rewrites that resolve `*.uds.dev` requests to the UDS Core Istio tenant and admin gateways."
-    autoIndent: true
-    default: |
-      rewrite {
-        name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
-      }
-      rewrite {
-        name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
-      }
-
 components:
   - name: destroy-cluster
     required: true
@@ -103,6 +91,11 @@ components:
         version: 0.2.0
         valuesFiles:
           - "values/dev-stack-values.yaml"
+        variables:
+          - name: COREDNS_OVERRIDES
+            # Defaults contain rewrites of `*.uds.dev` to the UDS core Istio tenant and admin gateways
+            description: "CoreDNS overrides"
+            path: coreDnsOverrides
       - name: minio
         namespace: uds-dev-stack
         version: 5.2.0

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -88,7 +88,9 @@ components:
       - name: uds-dev-stack
         namespace: uds-dev-stack
         localPath: chart
-        version: 0.2.0
+        # x-release-please-start-version
+        version: 0.9.0
+        # x-release-please-end
         valuesFiles:
           - "values/dev-stack-values.yaml"
         variables:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -32,8 +32,11 @@ variables:
       "CoreDNS overrides for rewriting requests. Defaults for `*.uds.dev` are the UDS Core Istio tenant and admin gateways."
     autoIndent: true
     default: |
-      rewrite stop {
-        name regex (.*\.uds\.dev) host.k3d.internal answer auto
+      rewrite {
+        name regex (.*admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto
+      }
+      rewrite {
+        name regex (.*\.uds\.dev) tenant-ingressgateway.istio-tenant-gateway.svc.cluster.local answer auto
       }
 
 components:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -30,6 +30,7 @@ variables:
   - name: COREDNS_OVERRIDES
     description: |
       "CoreDNS overrides for rewriting requests. Defaults for `*.uds.dev` are the UDS Core Istio tenant and admin gateways."
+    autoIndent: true
     default: |
       rewrite stop {
         name regex (.*\.uds\.dev) host.k3d.internal answer auto

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -93,6 +93,11 @@ components:
         # x-release-please-end
         valuesFiles:
           - "values/dev-stack-values.yaml"
+        variables:
+          - name: COREDNS_OVERRIDES
+            # Defaults contain rewrites of `*.uds.dev` to the UDS core Istio tenant and admin gateways
+            description: "CoreDNS overrides"
+            path: coreDnsOverrides
       - name: minio
         namespace: uds-dev-stack
         version: 5.2.0

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -27,6 +27,12 @@ variables:
     description: "Optionally allow more ports through Nginx (combine with K3D_EXTRA_ARGS '-p <port>:<port>@server:*')"
     default: "[]"
 
+  - name: COREDNS_OVERRIDES
+    description: |
+      "CoreDNS rewrites beyond the default overrides for UDS Core"
+    autoIndent: true
+    default: ""
+
 components:
   - name: destroy-cluster
     required: true
@@ -93,11 +99,6 @@ components:
         # x-release-please-end
         valuesFiles:
           - "values/dev-stack-values.yaml"
-        variables:
-          - name: COREDNS_OVERRIDES
-            # Defaults contain rewrites of `*.uds.dev` to the UDS core Istio tenant and admin gateways
-            description: "CoreDNS overrides"
-            path: coreDnsOverrides
       - name: minio
         namespace: uds-dev-stack
         version: 5.2.0

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -27,6 +27,14 @@ variables:
     description: "Optionally allow more ports through Nginx (combine with K3D_EXTRA_ARGS '-p <port>:<port>@server:*')"
     default: "[]"
 
+  - name: COREDNS_OVERRIDES
+    description: |
+      "CoreDNS overrides for rewriting requests. Defaults for `*.uds.dev` are the UDS Core Istio tenant and admin gateways."
+    default: |
+      rewrite stop {
+        name regex (.*\.uds\.dev) host.k3d.internal answer auto
+      }
+
 components:
   - name: destroy-cluster
     required: true

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -27,9 +27,9 @@ variables:
     description: "Optionally allow more ports through Nginx (combine with K3D_EXTRA_ARGS '-p <port>:<port>@server:*')"
     default: "[]"
 
-  - name: COREDNS_OVERRIDES
+  - name: COREDNS_DEFAULTS
     description: |
-      "CoreDNS overrides for rewriting requests. Defaults for `*.uds.dev` are the UDS Core Istio tenant and admin gateways."
+      "Default CoreDNS rewrites that resolve `*.uds.dev` requests to the UDS Core Istio tenant and admin gateways."
     autoIndent: true
     default: |
       rewrite {

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -27,12 +27,6 @@ variables:
     description: "Optionally allow more ports through Nginx (combine with K3D_EXTRA_ARGS '-p <port>:<port>@server:*')"
     default: "[]"
 
-  - name: COREDNS_OVERRIDES
-    description: |
-      "CoreDNS rewrites beyond the default overrides for UDS Core"
-    autoIndent: true
-    default: ""
-
 components:
   - name: destroy-cluster
     required: true


### PR DESCRIPTION
## Description

Implements an alternative CoreDNS override that relies on UDS Core's base service mesh, Istio. Uses the admin and tenant ingress gateways as the rewrite targets to gracefully handle ungraceful Docker restarts/stops, where `host.k3d.internal` fails. Also handles the case of integrating and routing to potential/future alternative service meshes via CoreDNS (e.g., kong). Another added benefit is the end-user's ability to add further rewrites based on additional or alternative gateways, domains, subdomains, services and/or virtual services.

## Related Issue

Fixes #99

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed