### PR TITLE
feat: add ability to override nginx domain

### DIFF
--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -12,7 +12,7 @@ data:
     stream {
         map $ssl_preread_server_name $selected_upstream {
             hostnames;  
-            *.admin.{{ .Values.domain }} backend_admin;
+            *.{{ .Values.adminDomain }} backend_admin;
             *.{{ .Values.domain }} backend_tenant;
             {{- if .Values.customGateway | default false}}
             *.{{ .Values.customGateway.domainName }} backend_custom_gateway;

--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -11,8 +11,12 @@ data:
 
     stream {
         map $ssl_preread_server_name $selected_upstream {
-            hostnames;  
+            hostnames;
+            {{- if .Values.adminDomain }}
             *.{{ .Values.adminDomain }} backend_admin;
+            {{- else }}
+            *.admin.{{ .Values.domain }} backend_admin;
+            {{- end }}
             *.{{ .Values.domain }} backend_tenant;
             {{- if .Values.customGateway | default false}}
             *.{{ .Values.customGateway.domainName }} backend_custom_gateway;

--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -12,8 +12,8 @@ data:
     stream {
         map $ssl_preread_server_name $selected_upstream {
             hostnames;  
-            *.admin.uds.dev backend_admin;
-            *.uds.dev backend_tenant;
+            *.admin.{{ .Values.domain }} backend_admin;
+            *.{{ .Values.domain }} backend_tenant;
             {{- if .Values.customGateway | default false}}
             *.{{ .Values.customGateway.domainName }} backend_custom_gateway;
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,7 @@
 extraPorts: []
 
-domain: uds.dev
+domain: "###ZARF_VAR_DOMAIN###"
+adminDomain: "###ZARF_VAR_ADMIN_DOMAIN###"
 
 coreDnsOverrides: |
   rewrite stop {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,7 @@
 extraPorts: []
 
+domain: uds.dev
+
 coreDnsOverrides: |
   rewrite stop {
     name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,8 +1,5 @@
 extraPorts: []
 
-domain: "###ZARF_VAR_DOMAIN###"
-adminDomain: "###ZARF_VAR_ADMIN_DOMAIN###"
-
 coreDnsOverrides: |
   rewrite stop {
     name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto

--- a/values/dev-stack-values.yaml
+++ b/values/dev-stack-values.yaml
@@ -1,1 +1,4 @@
 extraPorts: ###ZARF_VAR_NGINX_EXTRA_PORTS###
+
+domain: "###ZARF_VAR_DOMAIN###"
+adminDomain: "###ZARF_VAR_ADMIN_DOMAIN###"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -27,6 +27,13 @@ variables:
     description: "Optionally allow more ports through Nginx (combine with K3D_EXTRA_ARGS '-p <port>:<port>@server:*')"
     default: "[]"
 
+  - name: DOMAIN
+    description: "Cluster domain"
+    default: "uds.dev"
+
+  - name: ADMIN_DOMAIN
+    description: "Domain for admin services, defaults to `admin.DOMAIN`"
+
 components:
   - name: destroy-cluster
     required: true


### PR DESCRIPTION
## Description

Adds the ability to override the nginx domain.  This is helpful for scenarios in which you want to setup uds-k3d with a domain other than uds.dev.  It will be useful for setting up demo/dev environments that don't use uds.dev.  Useful for the runtime folks as they are doing [something nasty ](https://github.com/defenseunicorns/uds-runtime/blob/main/.github/test-infra/terraform/setup.sh#L11-L17)to get this working.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed