### PR TITLE
fix: Add a wait after deploying the k3d cluster so that slow internet connections don't get errors

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -63,6 +63,7 @@ components:
               ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"
         onSuccess:
+          # Wait for CoreDNS to be available. This allows slow internet connections to complete before we move on and try to connect to a cluster that may or may not be ready to accept connections. CoreDNS is a deployment we can trust will always be there.
           - wait:
               cluster:
                 kind: Pod
@@ -80,7 +81,6 @@ components:
               echo "This cluster can be destroyed with:"
               echo "k3d cluster delete ${ZARF_VAR_CLUSTER_NAME}"
             description: "Print out information about how to access the cluster remotely"
-          # Wait for CoreDNS to be available. This allows slow internet connections to complete before we move on and try to connect to a cluster that may or may not be ready to accept connections. CoreDNS is a deployment we can trust will always be there.
 
   - name: uds-dev-stack
     required: true

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -63,6 +63,13 @@ components:
               ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"
         onSuccess:
+          - wait:
+              cluster:
+                kind: deployment
+                condition: available
+                name: coredns
+                namespace: kube-system
+            description: "Wait for CoreDNS to be ready"
           - cmd: |
               echo "You can access this cluster over SSH (note http redirect will redirect to port 80 instead of 8080):"
               echo "ssh -N -L 8080:localhost:80 -L 8443:localhost:443 -L 6550:localhost:6550"
@@ -74,13 +81,6 @@ components:
               echo "k3d cluster delete ${ZARF_VAR_CLUSTER_NAME}"
             description: "Print out information about how to access the cluster remotely"
           # Wait for CoreDNS to be available. This allows slow internet connections to complete before we move on and try to connect to a cluster that may or may not be ready to accept connections. CoreDNS is a deployment we can trust will always be there.
-          - wait:
-              cluster:
-                kind: deployment
-                condition: available
-                name: coredns
-                namespace: kube-system
-            description: "Wait for CoreDNS to be ready"
 
   - name: uds-dev-stack
     required: true

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -80,6 +80,7 @@ components:
                 condition: available
                 name: coredns
                 namespace: kube-system
+            description: "Wait for CoreDNS to be ready"
 
   - name: uds-dev-stack
     required: true

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -65,9 +65,9 @@ components:
         onSuccess:
           - wait:
               cluster:
-                kind: deployment
-                condition: available
-                name: coredns
+                kind: Pod
+                condition: Ready
+                name: "k8s-app=kube-dns"
                 namespace: kube-system
             description: "Wait for CoreDNS to be ready"
           - cmd: |

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -73,6 +73,14 @@ components:
               echo "This cluster can be destroyed with:"
               echo "k3d cluster delete ${ZARF_VAR_CLUSTER_NAME}"
             description: "Print out information about how to access the cluster remotely"
+          # Wait for CoreDNS to be available. This allows slow internet connections to complete before we move on and try to connect to a cluster that may or may not be ready to accept connections. CoreDNS is a deployment we can trust will always be there.
+          - wait:
+              cluster:
+                kind: deployment
+                condition: available
+                name: coredns
+                namespace: kube-system
+
 
   - name: uds-dev-stack
     required: true

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -81,7 +81,6 @@ components:
                 name: coredns
                 namespace: kube-system
 
-
   - name: uds-dev-stack
     required: true
     description: "Install MetalLB, NGINX, Minio, local-path-rwx and Ensure MachineID to meet UDS developer needs without later config changes"


### PR DESCRIPTION
## Description
Adds a wait after k3d cluster deployment so that slow internet connections don't get errors.
...

## Related Issue

Fixes #137

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed