### PR TITLE
chore!: upgrade k3s version, add k3d version check

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         image: ["rancher/k3s"]
-        version: ["v1.29.8-k3s1", "v1.30.4-k3s1", "v1.31.0-k3s1"]
+        version: ["v1.30.8-k3s1", "v1.31.4-k3s1", "v1.32.0-k3s1"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ sudo ssh -N -L 80:localhost:80 -L 443:localhost:443 -L 6550:localhost:6550 <your
 
 ## Prerequisites
 
-- [UDS CLI](https://github.com/defenseunicorns/uds-cli/blob/main/README.md#install) & [K3d](https://k3d.io/#installation) using the versions specified in the [uds-common repo](https://github.com/defenseunicorns/uds-common/blob/main/README.md#supported-tool-versions)
+- [UDS CLI](https://uds.defenseunicorns.com/reference/cli/quickstart-and-usage/#install): version 0.20.0 or later
+- [K3d](https://k3d.io/#installation): version 5.7.1 or later
 - [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/getting-started/installation) for running K3d
 
 ## Deploy

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,10 @@
       "changelog-sections": [
         { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug Fixes", "hidden": false },
-        { "type": "chore", "section": "Miscellaneous", "hidden": false }
+        { "type": "chore", "section": "Miscellaneous", "hidden": false },
+        { "type": "docs", "section": "Documentation", "hidden": false }
       ],
+      "bump-minor-pre-major": true,
       "versioning": "default",
       "extra-files": ["README.md", "zarf.yaml", "chart/Chart.yaml"]
     }

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    default: "rancher/k3s:v1.30.4-k3s1"
+    default: "rancher/k3s:v1.31.4-k3s1"
 
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"
@@ -50,6 +50,15 @@ components:
     actions:
       onDeploy:
         before:
+          - cmd: |
+              k3d_version=$(k3d version | awk '/k3d version/ {print $3}' | sed 's/^v//')
+              required_version="5.7.1"
+              if [ "$(printf "%s\n%s" "$required_version" "$k3d_version" | sort -V | head -n 1)" != "$required_version" ]; then
+                echo "This package requires a minimum k3d version of $required_version"
+                echo "Please upgrade k3d (https://k3d.io/stable/#install-current-latest-release) and try again"
+                exit 1
+              fi
+            description: "Check k3d version compatibility"
           - cmd: |
               k3d cluster create \
               -p "80:80@server:*" \

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -51,9 +51,9 @@ components:
       onDeploy:
         before:
           - cmd: |
-              k3d_version=$(k3d version | awk '/k3d version/ {print $3}' | sed 's/^v//')
+              k3d_version=$(k3d version | grep -E -o "([0-9]+\.?){3}$")
               required_version="5.7.1"
-              if [ "$(printf "%s\n%s" "$required_version" "$k3d_version" | sort -V | head -n 1)" != "$required_version" ]; then
+              if ! echo "$required_version\n$k3d_version" | sort -V -C; then
                 echo "This package requires a minimum k3d version of $required_version"
                 echo "Please upgrade k3d (https://k3d.io/stable/#install-current-latest-release) and try again"
                 exit 1


### PR DESCRIPTION
## Description

BREAKING CHANGE: This package will now strictly enforce a k3d version of 5.7.1 or higher during deployment. While this will cause failures where it wouldn't have before, this aligns with the minimum known working k3d version that is compatible with this package.

This implements an action before deploy that uses standard linux/mac utilities to extract the k3d version and compare it to a minimum version (5.7.1). If the version is not at or above this version the deploy will fail with a message to the user to upgrade their version.

In addition this upgrades to the latest n-1 k3s image by default (`v1.31.4-k3s1`) and the latest patch versions of the latest 3 minors for CI.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-k3d/issues/139

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed