### PR TITLE
chore: update to k3s 1.31.6 by default

### DIFF
--- a/.github/actions/debug-output/action.yaml
+++ b/.github/actions/debug-output/action.yaml
@@ -1,0 +1,30 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+name: debug-output
+description: "Print out basic debug info for a k8s cluster"
+
+runs:
+  using: composite
+  steps:
+    - name: Print basic debug info for a k8s cluster
+      run: |
+        echo "::group::kubectl get all"
+        uds zarf tools kubectl get all -A | tee /tmp/debug-k-get-all.log || true
+        echo "::endgroup::"
+        echo "::group::kubectl get pods -A -o yaml"
+        uds zarf tools kubectl get pods -A -o yaml | tee /tmp/debug-k-get-pods.log || true
+        echo "::endgroup::"
+        echo "::group::kubectl get pv,pvc"
+        uds zarf tools kubectl get pv,pvc -A | tee /tmp/debug-k-get-pv-pvc.log || true
+        echo "::endgroup::"
+        echo "::group::kubectl get package"
+        uds zarf tools kubectl get package -A | tee /tmp/debug-k-get-package.log || true
+        echo "::endgroup::"
+        echo "::group::kubectl get events"
+        uds zarf tools kubectl get events -A --sort-by='.lastTimestamp' | tee /tmp/debug-k-get-events.log || true
+        echo "::endgroup::"
+        echo "::group::kubectl describe nodes"
+        uds zarf tools kubectl describe nodes | tee /tmp/debug-k-describe-node.log || true
+        echo "::endgroup::"
+      shell: bash

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -47,3 +47,7 @@ jobs:
 
       - name: Validate uds-k3d package
         run: uds run validate --no-progress
+
+      - name: Debug Output
+        if: ${{ always() }}
+        uses: ./.github/actions/debug-output

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         image: ["rancher/k3s"]
-        version: ["v1.30.8-k3s1", "v1.31.4-k3s1", "v1.32.0-k3s1"]
+        version: ["v1.30.10-k3s1", "v1.31.6-k3s1", "v1.32.2-k3s1"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    default: "rancher/k3s:v1.31.4-k3s1"
+    default: "rancher/k3s:v1.31.6-k3s1"
 
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"


### PR DESCRIPTION
## Description

Updates to latest 1.31.x by default and latest patch versions for CI testing.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed