### PR TITLE
chore: switch to cgr busybox

### DIFF
--- a/chart/templates/localpath-rwx.yaml
+++ b/chart/templates/localpath-rwx.yaml
@@ -116,7 +116,5 @@ data:
     spec:
       containers:
       - name: helper-pod
-        image: busybox
+        image: cgr.dev/chainguard/busybox:latest
         imagePullPolicy: IfNotPresent
-
-

--- a/chart/templates/localpath-rwx.yaml
+++ b/chart/templates/localpath-rwx.yaml
@@ -118,3 +118,7 @@ data:
       - name: helper-pod
         image: cgr.dev/chainguard/busybox:latest
         imagePullPolicy: IfNotPresent
+        # This runs as root to have permissions on the host filesystem
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0


### PR DESCRIPTION
## Description

Switches to the free latest cgr image for busybox to avoid dockerhub rate limiting.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed