### PR TITLE
chore: use k3s 1.31.7 by default

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         image: ["rancher/k3s"]
-        version: ["v1.30.10-k3s1", "v1.31.6-k3s1", "v1.32.2-k3s1"]
+        version: ["v1.30.11-k3s1", "v1.31.7-k3s1", "v1.32.3-k3s1"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -3,7 +3,7 @@ includes:
 
 variables:
   - name: VERSION
-    default: "v1.30.4-k3s1"
+    default: "v1.31.7-k3s1"
   - name: IMAGE_NAME
     default: "rancher/k3s"
   - name: K3D_EXTRA_ARGS

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    default: "rancher/k3s:v1.31.6-k3s1"
+    default: "rancher/k3s:v1.31.7-k3s1"
 
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"


### PR DESCRIPTION
## Description

Update to 1.31.7 by default, latest patch versions for CI.

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed