### PR TITLE
chore: update minio, switch to quay nginx

### DIFF
--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -5,11 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   nginx.conf: |
-    # The stream module is dynamically loaded in the Chainguard nginx image.
-    # This directive is required to use the stream{} block for SNI-based routing without SSL termination.
-    # The module is installed via apk in the container startup command.
-    load_module /usr/lib/nginx/modules/ngx_stream_module.so;
-
     events {
         worker_connections  1024;
     }
@@ -69,6 +64,8 @@ data:
       }
     }
 
+    pid /tmp/nginx.pid;
+
     error_log /dev/stderr;
 
 ---
@@ -89,14 +86,9 @@ spec:
     spec:
       containers:
         - name: nginx
-          # This is Chainguard's latest-dev image, pinned as of 04/07/25 - nginx/1.27.4
-          image: cgr.dev/chainguard/nginx:latest-dev@sha256:de240fb7bf27fd62ddbe4f81c592bc1d385210a59f14e292548d3790038b7e6a
-          command:
-            - /bin/sh
-            - -c
-            - |
-              apk add nginx-mod-stream
-              nginx -g "daemon off;"
+          # This is pulled from quay.io to avoid rate limiting
+          image: quay.io/nginx/nginx-unprivileged:1.27.4-alpine3.21
+          command: ["nginx", "-g", "daemon off;"]
           ports:
             - containerPort: 80
               hostPort: 80
@@ -106,9 +98,6 @@ spec:
             - containerPort: {{ . }}
               hostPort: {{ . }}
           {{- end }}
-          securityContext:
-            # Required for `apk add` during startup, matches upstream image
-            runAsUser: 0
           volumeMounts:
             - name: config-volume
               mountPath: /etc/nginx/nginx.conf

--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -64,6 +64,7 @@ data:
       }
     }
 
+    # The unprivileged nginx image requires the PID to be in /tmp (https://github.com/nginx/docker-nginx-unprivileged)
     pid /tmp/nginx.pid;
 
     error_log /dev/stderr;

--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   nginx.conf: |
+    # The stream module is dynamically loaded in the Chainguard nginx image.
+    # This directive is required to use the stream{} block for SNI-based routing without SSL termination.
+    # The module is installed via apk in the container startup command.
+    load_module /usr/lib/nginx/modules/ngx_stream_module.so;
+
     events {
         worker_connections  1024;
     }
@@ -84,9 +89,14 @@ spec:
     spec:
       containers:
         - name: nginx
-          # This is a copy of the official nginx 1.25.3 image on GHCR to avoid rate limiting
-          image: ghcr.io/defenseunicorns/oss/uds-k3d-nginx:alpine-1.25.3
-          command: ["nginx", "-g", "daemon off;"]
+          # This is Chainguard's latest-dev image, pinned as of 04/07/25 - nginx/1.27.4
+          image: cgr.dev/chainguard/nginx:latest-dev@sha256:de240fb7bf27fd62ddbe4f81c592bc1d385210a59f14e292548d3790038b7e6a
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add nginx-mod-stream
+              nginx -g "daemon off;"
           ports:
             - containerPort: 80
               hostPort: 80
@@ -96,6 +106,9 @@ spec:
             - containerPort: {{ . }}
               hostPort: {{ . }}
           {{- end }}
+          securityContext:
+            # Required for `apk add` during startup, matches upstream image
+            runAsUser: 0
           volumeMounts:
             - name: config-volume
               mountPath: /etc/nginx/nginx.conf

--- a/values/minio-values.yaml
+++ b/values/minio-values.yaml
@@ -1,6 +1,11 @@
 replicas: 1
 mode: standalone
 
+image:
+  repository: quay.io/minio/minio
+  # renovate: datasource=docker depName=quay.io/minio/minio versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
+  tag: RELEASE.2025-04-03T14-56-28Z
+
 # Some reasonable requests instead of the bonkers defaults
 resources:
   requests:


### PR DESCRIPTION
## Description

Updates to the latest minio image + adds renovate on the image tag.

Also switches to the quay unprivileged nginx image. This keeps us from any rate limiting issues, but also doesn't require us to mirror the image to GHCR. I also tested the chainguard nginx image, but that required running some additional `apk add` commands during startup (also requiring more privileges) so I pivoted to this simpler approach. This image should also be automatically renovated, or alternatively we can switch to one of the "less pinned" variants (`1.27-alpine` for example) to reduce the frequency of updates.

### Testing

From uds-k3d repo:
```
uds run
```

From uds-core repo, deploy the base/SSO stack to validate the Istio gateways:
```
uds run -f tasks/create.yaml k3d-slim-dev-bundle
# Note this is specific to the build you did (version/arch) - important part is the `--packages` flag
uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-core-slim-dev-arm64-0.39.0.tar.zst --packages init,core-base,core-identity-authorization
```

Validate you can navigate to https://keycloak.admin.uds.dev/ and https://sso.uds.dev/ (tests nginx for both gateways)

From uds-core repo, deploy the logging stack to validate minio functionality:
```
uds run test:single-layer --set LAYER=logging
```

(if this passes Loki is properly shipping logs to MinIO)


## Related Issue

N/A - just dependency updates.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed