### PR TITLE
feat: `uds-k3d` airgap package flavor

### DIFF
--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: airgap-package-${{ matrix.architecture }}
-          path: ./build
+          path: .
 
       - name: Install UDS CLI
         uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
@@ -91,11 +91,7 @@ jobs:
 
 
       - name: Deploy the airgap package
-        run: |
-          # Navigate to where the artifact was downloaded
-          cd ./build
-          # Adjust the command to use the downloaded package path
-          uds zarf package deploy zarf-package-uds-k3d-*.tar.zst --confirm --no-progress
+        run: uds run deploy-airgap-package --no-progress
         shell: bash
       
       - name: Validate uds-k3d package

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -1,0 +1,101 @@
+name: Test UDS Airgap Capability
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "CODEOWNERS"
+  workflow_call:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-package:
+    name: Build Airgap Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install UDS CLI
+        uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
+        with:
+          # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+          version: v0.27.1
+
+      - name: Environment setup
+        run: |
+            uds run actions:setup-environment \
+            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
+            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+        shell: bash
+
+      - name: Create the airgap package
+        run: uds run build-airgap-package
+
+      - name: Upload Airgap Package Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: airgap-package
+          path: ./zarf-package-uds-k3d-*.tar.zst
+
+  deploy-airgap:
+    name: Deploy Airgap Package
+    runs-on: ubuntu-latest
+    needs: build-package # This job depends on the build-package job completing successfully
+
+    steps:
+      - name: Harden Runner - Block Egress
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com
+            objects.githubusercontent.com
+            api.github.com
+            raw.githubusercontent.com
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download Airgap Package Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: airgap-package
+          path: ./build
+
+      - name: Install UDS CLI
+        uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
+        with:
+          version: v0.27.1
+      
+      - name: Download Zarf Init Package
+        run: |
+          ZARF_VERSION=$(uds zarf version)
+          curl -L https://github.com/zarf-dev/zarf/releases/download/${ZARF_VERSION}/zarf-init-amd64-${ZARF_VERSION}.tar.zst -o zarf-init-amd64-${ZARF_VERSION}.tar.zst
+
+      - name: Install deps
+        run: |
+          uds run actions:install-deps
+        shell: bash
+
+
+      - name: Deploy the airgap package
+        run: |
+          # Navigate to where the artifact was downloaded
+          cd ./build
+          # Adjust the command to use the downloaded package path
+          uds zarf package deploy zarf-package-uds-k3d-*.tar.zst --confirm --no-progress
+        shell: bash
+      
+      - name: Validate uds-k3d package
+        run: |
+          uds run validate-airgap --no-progress
+        shell: bash
+
+      - name: Debug Output
+        if: ${{ always() }}
+        uses: ./.github/actions/debug-output

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -16,6 +16,9 @@ jobs:
   build-package:
     name: Build Airgap Package
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [amd64, arm64]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -35,18 +38,22 @@ jobs:
         shell: bash
 
       - name: Create the airgap package
-        run: uds run build-airgap-package
+        run: uds run build-airgap-package --set ARCH=${{ matrix.architecture }}
 
       - name: Upload Airgap Package Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
-          name: airgap-package
+          name: airgap-package-${{ matrix.architecture }}
           path: ./zarf-package-uds-k3d-*.tar.zst
+          retention-days: 1
 
   deploy-airgap:
     name: Deploy Airgap Package
     runs-on: ubuntu-latest
     needs: build-package # This job depends on the build-package job completing successfully
+    strategy:
+      matrix:
+        architecture: [amd64] # Only test with amd64 for deployment
 
     steps:
       - name: Harden Runner - Block Egress
@@ -64,7 +71,7 @@ jobs:
       - name: Download Airgap Package Artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: airgap-package
+          name: airgap-package-${{ matrix.architecture }}
           path: ./build
 
       - name: Install UDS CLI

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,12 +13,46 @@ permissions:
   contents: read
 
 jobs:
+  build-package:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install UDS CLI
+        uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
+        with:
+          # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+          version: v0.27.2
+
+      - name: Environment setup
+        run: |
+            uds run actions:setup-environment \
+            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
+            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+        shell: bash
+
+      - name: Create uds-k3d package
+        run: uds run build --set ARCH=${{ matrix.architecture }} --no-progress
+      
+      - name: Upload Package Artifact
+        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package-${{ matrix.architecture }}
+          path: ./zarf-package-uds-k3d-*.tar.zst
+          retention-days: 1
+
   test-clean-install:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         image: ["rancher/k3s"]
         version: ["v1.31.8-k3s1", "v1.32.4-k3s1", "v1.33.0-k3s1"]
+        architecture: ["amd64"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,13 +72,19 @@ jobs:
             --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
+      - name: Download Package Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package-${{ matrix.architecture }}
+          path: ./build
+
       # Step is not currently being used, could be uncommented if custom image support is needed in the future
       # - name: Build the custom k3s image
       #   if: ${{matrix.image}} != "rancher/k3s"
       #   run: uds run build-image --set VERSION=${{matrix.version}} --no-progress
 
       - name: Create and deploy the uds-k3d package
-        run: uds run --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
+        run: uds run deploy --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
 
       - name: Validate uds-k3d package
         run: uds run validate --no-progress

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: package-${{ matrix.architecture }}
-          path: ./build
+          path: .
 
       # Step is not currently being used, could be uncommented if custom image support is needed in the future
       # - name: Build the custom k3s image
@@ -85,7 +85,9 @@ jobs:
       #   run: uds run build-image --set VERSION=${{matrix.version}} --no-progress
 
       - name: Create and deploy the uds-k3d package
-        run: uds run deploy --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
+        run: |
+          cd build
+          uds run deploy --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
 
       - name: Validate uds-k3d package
         run: uds run validate --no-progress

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -6,6 +6,7 @@ on:
       - "**.md"
       - "docs/**"
       - "CODEOWNERS"
+  workflow_call:
 
 permissions:
   id-token: write

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,7 +40,7 @@ jobs:
         run: uds run build --set ARCH=${{ matrix.architecture }} --no-progress
       
       - name: Upload Package Artifact
-        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: package-${{ matrix.architecture }}
           path: ./zarf-package-uds-k3d-*.tar.zst
@@ -48,6 +48,7 @@ jobs:
 
   test-clean-install:
     runs-on: ubuntu-latest
+    needs: build-package
     strategy:
       matrix:
         image: ["rancher/k3s"]

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -85,9 +85,7 @@ jobs:
       #   run: uds run build-image --set VERSION=${{matrix.version}} --no-progress
 
       - name: Create and deploy the uds-k3d package
-        run: |
-          cd build
-          uds run deploy --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
+        run: uds run deploy --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
 
       - name: Validate uds-k3d package
         run: uds run validate --no-progress

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -69,7 +69,18 @@ jobs:
             --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
         shell: bash
 
-      - name: Publish the capability
+      - name: Download Airgap Package Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: airgap-package-${{ matrix.architecture }}
+          path: ./airgap-build
+      - name: Download Standard Package Artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package-${{ matrix.architecture }}
+          path: ./standard-build
+
+      - name: Publish the packages
         run: |
-          uds zarf package create --confirm -a ${{ matrix.architecture }} -o oci://ghcr.io/defenseunicorns/packages
-          uds zarf package create --confirm -a ${{ matrix.architecture }} --flavor airgap -o oci://ghcr.io/defenseunicorns/packages
+          uds zarf package publish ./airgap-package/zarf-package-uds-k3d-${{ matrix.architecture }}.tar.zst -o oci://ghcr.io/defenseunicorns/packages
+          uds zarf package publish ./standard-package/zarf-package-uds-k3d-${{ matrix.architecture }}.tar.zst -o oci://ghcr.io/defenseunicorns/packages

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -6,8 +6,18 @@ on:
       - main
 
 jobs:
+  
+  # Run standard build tests first
+  run-build-test:
+    uses: ./.github/workflows/build-test.yaml
+
+  # Run airgap build tests
+  run-airgap-build-test:
+    uses: ./.github/workflows/airgap-build-test.yaml
+
+  # Only proceed to tag a new version if all tests pass
   tag-new-version:
-    permissions: write-all
+    needs: [run-build-test, run-airgap-build-test]
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release-flag.outputs.release_created }}
@@ -24,6 +34,11 @@ jobs:
     needs: tag-new-version
     if: ${{ needs.tag-new-version.outputs.release_created == 'true'}}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture:
+          - arm64
+          - amd64
 
     permissions:
       contents: read
@@ -50,5 +65,5 @@ jobs:
 
       - name: Publish the capability
         run: |
-          uds zarf package create --confirm -a arm64 -o oci://ghcr.io/defenseunicorns/packages
-          uds zarf package create --confirm -a amd64 -o oci://ghcr.io/defenseunicorns/packages
+          uds zarf package create --confirm -a ${{ matrix.architecture }} -o oci://ghcr.io/defenseunicorns/packages
+          uds zarf package create --confirm -a ${{ matrix.architecture }} --flavor airgap -o oci://ghcr.io/defenseunicorns/packages

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -23,6 +23,7 @@ jobs:
 
   # Only proceed to tag a new version if all tests pass
   tag-new-version:
+    permissions: write-all
     needs: [run-build-test, run-airgap-build-test]
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -10,10 +10,16 @@ jobs:
   # Run standard build tests first
   run-build-test:
     uses: ./.github/workflows/build-test.yaml
+    permissions:
+      id-token: write
+      contents: read
 
   # Run airgap build tests
   run-airgap-build-test:
     uses: ./.github/workflows/airgap-build-test.yaml
+    permissions:
+      id-token: write
+      contents: read
 
   # Only proceed to tag a new version if all tests pass
   tag-new-version:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 zarf-sbom
 tmp/
 zarf-config.yaml
+*.tar

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ package:
 ### DNS Assumptions
 
 - [DNS Assumptions](docs/DNS.md)
+
+### Airgap Flavor
+
+- [Airgap](docs/AIRGAP.md)

--- a/airgap/k3d/zarf.yaml
+++ b/airgap/k3d/zarf.yaml
@@ -1,0 +1,49 @@
+kind: ZarfPackageConfig
+metadata:
+  name: k3d-airgap-images
+  yolo: true
+  description: >
+    *** REQUIRES DOCKER ***
+    Loads the required images for K3d into Docker to be used offline.
+
+constants:
+  - name: K3S_VERSION
+    value: "###ZARF_PKG_TMPL_K3S_VERSION###"
+components:
+  - name: k3d-airgap-images
+    files:
+      # Transfer the K3d images for docker to use in the air gap
+      - source: k3d-proxy.tar
+        target: k3d-proxy.tar
+      - source: k3d-tools.tar
+        target: k3d-tools.tar
+      - source: k3d-image.tar
+        target: k3d-image.tar
+      - source: k3s-airgap-images.tar.zst
+        target: k3s-airgap-images.tar.zst
+
+    actions:
+      onCreate:
+        before:
+          # renovate: datasource=docker depName=ghcr.io/k3d-io/k3d-proxy
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/k3d-io/k3d-proxy:5.8.3 k3d-proxy.tar
+            description: Pull the 'k3d-proxy' image
+          # renovate: datasource=docker depName=ghcr.io/k3d-io/k3d-tools
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/k3d-io/k3d-tools:5.8.3 k3d-tools.tar
+            description: Pull the 'k3d-tools' image
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" rancher/k3s:"###ZARF_PKG_TMPL_K3S_VERSION###" k3d-image.tar
+            description: Pull the airgap 'k3s' image
+          - cmd: |
+              K3S_AIRGAP_IMAGES=$(echo "###ZARF_PKG_TMPL_K3S_VERSION###" | sed 's/-k3s/%2Bk3s/g')
+              curl -L https://github.com/k3s-io/k3s/releases/download/"${K3S_AIRGAP_IMAGES}"/k3s-airgap-images-"###ZARF_PKG_ARCH###".tar.zst -o k3s-airgap-images.tar.zst
+            description: Download the airgap 'k3s' images
+      onDeploy:
+        after:
+            - cmd: |
+                  docker image load -i k3d-proxy.tar
+                  docker image load -i k3d-tools.tar
+                  docker image load -i k3d-image.tar
+                  docker volume create k3s-airgap-images
+                  docker run --rm --entrypoint /bin/sh -v k3s-airgap-images:/dest -v .:/src rancher/k3s:${ZARF_CONST_K3S_VERSION} -c "cp /src/k3s-airgap-images.tar.zst /dest"
+                  rm k3d-proxy.tar k3d-tools.tar k3d-image.tar k3s-airgap-images.tar.zst
+              description: Load the airgap images for k3d into Docker

--- a/airgap/uds-dev-stack/zarf.yaml
+++ b/airgap/uds-dev-stack/zarf.yaml
@@ -34,23 +34,32 @@ components:
         before:
           # renovate: datasource=docker depName=rancher/local-path-provisioner
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" rancher/local-path-provisioner:v0.0.31 local-path-provisioner.tar
+            description: Pull the local-path-provisioner image
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" cgr.dev/chainguard/busybox:latest busybox.tar
+            description: Pull the busybox image
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" cgr.dev/chainguard/wolfi-base:latest wolfi-base.tar
+            description: Pull the wolfi-base image
           # renovate: datasource=docker depName=registry.k8s.io/pause
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" registry.k8s.io/pause:3.10 pause.tar
+            description: Pull the pause image
           # renovate: datasource=docker depName=quay.io/nginx/nginx-unprivileged versioning=docker
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/nginx/nginx-unprivileged:1.28.0-alpine nginx.tar
+            description: Pull the nginx image
           # renovate: datasource=docker depName=quay.io/metallb/controller
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/controller:v0.14.9 metallb-controller.tar
+            description: Pull the metallb-controller image
           # renovate: datasource=docker depName=quay.io/metallb/speaker
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/speaker:v0.14.9 metallb-speaker.tar
+            description: Pull the metallb-speaker image
           # renovate: datasource=docker depName=quay.io/frrouting/frr
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/frrouting/frr:9.1.0 frr.tar
+            description: Pull the frr image
           # renovate: datasource=docker depName=quay.io/minio/minio versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z minio.tar
+            description: Pull the minio image
           # renovate: datasource=docker depName=quay.io/minio/mc versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z minio-mc.tar
-            description: Pull the airgap images for uds-dev-stack
+            description: Pull the minio-mc image
       onDeploy:
         after:
           - cmd: |

--- a/airgap/uds-dev-stack/zarf.yaml
+++ b/airgap/uds-dev-stack/zarf.yaml
@@ -3,8 +3,8 @@ metadata:
   name: uds-dev-stack-airgap-images
   yolo: true
   description: >
-    *** REQUIRES DOCKER ***
-    Loads the required images for UDS Dev Stack into Docker to be used offline.
+    *** REQUIRES DOCKER AND K3D CLUSTER ***
+    Loads the required images for UDS Dev Stack into k3d to be used offline.
 
 components:
   - name: uds-dev-stack-airgap-images

--- a/airgap/uds-dev-stack/zarf.yaml
+++ b/airgap/uds-dev-stack/zarf.yaml
@@ -1,0 +1,70 @@
+kind: ZarfPackageConfig
+metadata:
+  name: uds-dev-stack-airgap-images
+  yolo: true
+  description: >
+    *** REQUIRES DOCKER ***
+    Loads the required images for UDS Dev Stack into Docker to be used offline.
+
+components:
+  - name: uds-dev-stack-airgap-images
+    files:
+      - source: local-path-provisioner.tar
+        target: local-path-provisioner.tar
+      - source: busybox.tar
+        target: busybox.tar
+      - source: wolfi-base.tar
+        target: wolfi-base.tar
+      - source: pause.tar
+        target: pause.tar
+      - source: nginx.tar
+        target: nginx.tar
+      - source: metallb-controller.tar
+        target: metallb-controller.tar
+      - source: metallb-speaker.tar
+        target: metallb-speaker.tar
+      - source: frr.tar
+        target: frr.tar
+      - source: minio.tar
+        target: minio.tar
+      - source: minio-mc.tar
+        target: minio-mc.tar
+    actions:
+      onCreate:
+        before:
+          # renovate: datasource=docker depName=rancher/local-path-provisioner
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" rancher/local-path-provisioner:v0.0.31 local-path-provisioner.tar
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" cgr.dev/chainguard/busybox:latest busybox.tar
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" cgr.dev/chainguard/wolfi-base:latest wolfi-base.tar
+          # renovate: datasource=docker depName=registry.k8s.io/pause
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" registry.k8s.io/pause:3.10 pause.tar
+          # renovate: datasource=docker depName=quay.io/nginx/nginx-unprivileged versioning=docker
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/nginx/nginx-unprivileged:1.28.0-alpine nginx.tar
+          # renovate: datasource=docker depName=quay.io/metallb/controller
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/controller:v0.14.9 metallb-controller.tar
+          # renovate: datasource=docker depName=quay.io/metallb/speaker
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/speaker:v0.14.9 metallb-speaker.tar
+          # renovate: datasource=docker depName=quay.io/frrouting/frr
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/frrouting/frr:9.1.0 frr.tar
+          # renovate: datasource=docker depName=quay.io/minio/minio versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z minio.tar
+          # renovate: datasource=docker depName=quay.io/minio/mc versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z minio-mc.tar
+            description: Pull the airgap images for uds-dev-stack
+      onDeploy:
+        after:
+          - cmd: |
+              k3d image load local-path-provisioner.tar \
+                busybox.tar \
+                wolfi-base.tar \
+                pause.tar \
+                nginx.tar \
+                metallb-controller.tar \
+                metallb-speaker.tar \
+                minio.tar \
+                minio-mc.tar \
+                frr.tar \
+                -c ${ZARF_VAR_CLUSTER_NAME}
+            description: Load the airgap images for uds-dev-stack into Docker
+          - cmd: rm pause.tar nginx.tar wolfi-base.tar busybox.tar local-path-provisioner.tar metallb-controller.tar metallb-speaker.tar minio.tar minio-mc.tar frr.tar
+            description: Cleanup the airgap image tars

--- a/chart/templates/localpath-rwx.yaml
+++ b/chart/templates/localpath-rwx.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: local-path-provisioner-service-account
       containers:
         - name: local-path-provisioner
-          image: rancher/local-path-provisioner:v0.0.31
+          image: {{.Values.images.localPathProvisioner.repository}}:{{.Values.images.localPathProvisioner.tag}}
           imagePullPolicy: IfNotPresent
           command:
             - local-path-provisioner
@@ -116,7 +116,7 @@ data:
     spec:
       containers:
       - name: helper-pod
-        image: cgr.dev/chainguard/busybox:latest
+        image: {{.Values.images.busybox.repository}}:{{.Values.images.busybox.tag}}
         imagePullPolicy: IfNotPresent
         # This runs as root to have permissions on the host filesystem
         securityContext:

--- a/chart/templates/machineid.yaml
+++ b/chart/templates/machineid.yaml
@@ -16,7 +16,8 @@ spec:
     spec:
       initContainers:
         - name: generate-machine-id
-          image: cgr.dev/chainguard/wolfi-base:latest
+          image: {{.Values.images.wolfiBase.repository}}:{{.Values.images.wolfiBase.tag}}
+          imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
           args:
             - echo "B0D07F1F43F246409516ADBDCCC86FCE" > /mnt/host/etc/machine-id;
@@ -29,7 +30,7 @@ spec:
             runAsUser: 0
       containers:
         - name: pause
-          image: registry.k8s.io/pause:3.10
+          image: {{.Values.images.pause.repository}}:{{.Values.images.pause.tag}}
           resources:
             limits:
               cpu: "0.1"

--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -109,8 +109,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          # This is pulled from quay.io to avoid rate limiting
-          image: quay.io/nginx/nginx-unprivileged:1.28.0-alpine3.21
+          image: {{ .Values.images.nginx.repository }}:{{ .Values.images.nginx.tag }}
           command: ["nginx", "-g", "daemon off;"]
           ports:
             - containerPort: 80

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,3 +19,22 @@ passthrough:
     # e.g.,
     # - mysubdomain
     # - myothersubdomain
+images:
+  nginx:
+    repository: quay.io/nginx/nginx-unprivileged
+    # renovate: datasource=docker depName=quay.io/nginx/nginx-unprivileged versioning=docker
+    tag: "1.28.0-alpine"
+  busybox:
+    repository: cgr.dev/chainguard/busybox
+    tag: "latest"
+  wolfiBase:
+    repository: cgr.dev/chainguard/wolfi-base
+    tag: "latest"
+  pause:
+    repository: registry.k8s.io/pause
+    # renovate: datasource=docker depName=registry.k8s.io/pause
+    tag: "3.10"
+  localPathProvisioner:
+    repository: rancher/local-path-provisioner
+    # renovate: datasource=docker depName=rancher/local-path-provisioner
+    tag:  "v0.0.31"

--- a/docs/AIRGAP.md
+++ b/docs/AIRGAP.md
@@ -1,0 +1,7 @@
+# Airgap Flavor
+
+This package can be deployed fully airgapped by using the `airgap` flavor. All of the images required for the `k3d` cluster to spin up are loaded into `docker` using `docker load` before the cluster is created. Then all of the images required for the `uds-dev-stack` are loaded into the `k3d` cluster using `k3d image load`.
+
+## Considerations
+
+The version of `k3s` that is deployed by the `airgap` flavor is static and not configurable. 

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -18,7 +18,7 @@ tasks:
     description: "Build uds-k3d"
     actions:
       - description: "Build UDS K3d package"
-        cmd: "uds zarf package create -a ${ARCH} --confirm --no-progress"
+        cmd: "uds zarf package create -a ${ARCH} --confirm --no-progress --skip-sbom"
 
   - name: deploy
     description: "Deploy uds-k3d package"
@@ -77,7 +77,7 @@ tasks:
       - description: Build the airgap package
         cmd: |
           uds zarf package create -a ${ARCH} --flavor airgap --confirm --no-progress \
-            --set K3S_VERSION="${VERSION}"
+            --set K3S_VERSION="${VERSION}" --skip-sbom
 
       - description: Clean up airgap images
         task: clean-airgap-images

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -10,17 +10,22 @@ variables:
     default: ""
   - name: NGINX_EXTRA_PORTS
     default: "[]"
+  - name: ARCH
+    default: "${UDS_ARCH}"
 
 tasks:
-  - name: default
-    description: "Build and deploy uds-k3d"
+  - name: build
+    description: "Build uds-k3d"
     actions:
       - description: "Build UDS K3d package"
-        cmd: "uds zarf package create --confirm --no-progress"
+        cmd: "uds zarf package create -a ${ARCH} --confirm --no-progress"
 
+  - name: deploy
+    description: "Deploy uds-k3d package"
+    actions:
       - description: "Deploy UDS K3d package"
         cmd: |
-          uds zarf package deploy zarf-package-uds-k3d-*.tar.zst \
+          uds zarf package deploy zarf-package-uds-k3d-${ARCH}-*.tar.zst \
             --set K3D_IMAGE=${IMAGE_NAME}:${VERSION} \
             --set K3D_EXTRA_ARGS="${K3D_EXTRA_ARGS}" \
             --set NGINX_EXTRA_PORTS="${NGINX_EXTRA_PORTS}" \
@@ -71,7 +76,7 @@ tasks:
     actions:
       - description: Build the airgap package
         cmd: |
-          uds zarf package create --flavor airgap --confirm --no-progress \
+          uds zarf package create -a ${ARCH} --flavor airgap --confirm --no-progress \
             --set K3S_VERSION="${VERSION}"
 
       - description: Clean up airgap images
@@ -81,7 +86,7 @@ tasks:
     actions:
       - description: Deploy the airgap package
         cmd: |
-          uds zarf package deploy zarf-package-uds-k3d-${UDS_ARCH}-*.tar.zst --no-progress --confirm
+          uds zarf package deploy zarf-package-uds-k3d-${ARCH}-*.tar.zst --no-progress --confirm
 
   - name: clean-airgap-images
     actions:

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -28,6 +28,18 @@ tasks:
 
   - name: validate
     actions:
+      - task: validate-coredns
+      - cmd: uds zarf tools download-init --no-progress
+        description: "Download the zarf init package"
+      - task: validate-zarf-init
+
+  - name: validate-airgap
+    actions:
+      - task: validate-coredns
+      - task: validate-zarf-init
+
+  - name: validate-coredns
+    actions:
       - description: Validate coredns is up
         wait:
           cluster:
@@ -38,19 +50,46 @@ tasks:
       - description: Validate coredns is resolving *.uds.dev internally
         cmd: |
           set -e
-          FOO_IP=$(uds zarf tools kubectl run dig-test --image=arunvelsriram/utils -q --restart=Never --rm -i -- dig +short foo.uds.dev)
+          # renovate: datasource=docker depName=quay.io/nginx/nginx-unprivileged versioning=docker
+          FOO_IP=$(kubectl run test --image=quay.io/nginx/nginx-unprivileged:1.28.0-alpine -q --restart=Never --rm -i -- sh -c "getent hosts foo.uds.dev | awk '{print \$1}'")
           if [ "${FOO_IP}" != "127.0.0.1" ]; then
             echo "CoreDNS is resolving foo.uds.dev to host.k3d.internal"
           else
             echo "CoreDNS patch failed, foo.uds.dev is resolving to 127.0.0.1"
             exit 1
           fi
+
+  - name: validate-zarf-init
+    actions:
       - description: Validate zarf init
         cmd: |
           set -e
-          uds zarf tools download-init --no-progress
           # Test zarf init due to containerd issue - https://github.com/defenseunicorns/zarf/issues/592
           uds zarf init --confirm --no-progress
+
+  - name: build-airgap-package
+    actions:
+      - description: Build the airgap package
+        cmd: |
+          uds zarf package create --flavor airgap --confirm --no-progress \
+            --set K3S_VERSION="${VERSION}"
+
+      - description: Clean up airgap images
+        task: clean-airgap-images
+
+  - name: deploy-airgap-package
+    actions:
+      - description: Deploy the airgap package
+        cmd: |
+          uds zarf package deploy zarf-package-uds-k3d-${UDS_ARCH}-*.tar.zst --no-progress --confirm
+
+  - name: clean-airgap-images
+    actions:
+      - description: Remove airgap images
+        cmd: |
+          rm airgap/uds-dev-stack/*.tar
+          rm airgap/k3d/*.tar
+          rm airgap/k3d/*.tar.zst
 
   # - name: build-image
   #   actions:

--- a/values/metallb-values.yaml
+++ b/values/metallb-values.yaml
@@ -1,0 +1,15 @@
+controller:
+  image:
+    repository: quay.io/metallb/controller
+    # renovate: datasource=docker depName=quay.io/metallb/controller
+    tag: "v0.14.9"
+speaker:
+  image:
+    repository: quay.io/metallb/speaker
+    # renovate: datasource=docker depName=quay.io/metallb/speaker
+    tag: "v0.14.9"
+frr:
+  image:
+    repository: quay.io/frrouting/frr
+    # renovate: datasource=docker depName=quay.io/frrouting/frr
+    tag: "v9.1.0"

--- a/values/minio-values.yaml
+++ b/values/minio-values.yaml
@@ -5,7 +5,10 @@ image:
   repository: quay.io/minio/minio
   # renovate: datasource=docker depName=quay.io/minio/minio versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
   tag: RELEASE.2025-04-22T22-12-26Z
-
+mcImage:
+  repository: quay.io/minio/mc
+  # renovate: datasource=docker depName=quay.io/minio/mc versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
+  tag: "RELEASE.2024-11-21T17-21-54Z"
 # Some reasonable requests instead of the bonkers defaults
 resources:
   requests:

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -33,7 +33,7 @@ variables:
 
   - name: ADMIN_DOMAIN
     description: "Domain for admin services, defaults to `admin.DOMAIN`"
-
+  
 components:
   - name: destroy-cluster
     required: true
@@ -44,7 +44,38 @@ components:
           - cmd: k3d cluster delete ${ZARF_VAR_CLUSTER_NAME}
             description: "Destroy the cluster"
 
-  - name: create-cluster
+  - name: k3d-airgap-images
+    required: true
+    only:
+      flavor: airgap
+    description: "Load the airgap images for k3d into Docker"
+    import:
+      path: airgap/k3d
+      name: k3d-airgap-images
+    
+  - name: create-cluster-airgap
+    required: true
+    only:
+      flavor: airgap
+    actions:
+      onDeploy:
+        before:
+          - cmd: |
+              echo ""
+              echo "###################################################"
+              echo "#                                                 #"
+              echo "#      PACKAGE BEING DEPLOYED IN AIRGAP MODE      #"
+              echo "#    THIS IS NOT MEANT TO BE USED IN PRODUCTION   #"
+              echo "#                                                 #"
+              echo "###################################################"
+              echo ""
+          - cmd: echo "true"
+            description: "Set AIRGAP_MODE to true"
+            mute: true
+            setVariables:
+              - name: AIRGAP_MODE
+
+  - name: create-cluster-no-airgap
     required: true
     description: "Create the k3d cluster"
     actions:
@@ -60,6 +91,12 @@ components:
               fi
             description: "Check k3d version compatibility"
           - cmd: |
+              VOLUME_MOUNT=""
+              if [ "${ZARF_VAR_AIRGAP_MODE}" = "true" ]; then
+                echo "AIRGAP_MODE"
+                export K3D_HELPER_IMAGE_TAG=5.8.3
+                VOLUME_MOUNT="--volume k3s-airgap-images:/var/lib/rancher/k3s/agent/images"
+              fi
               k3d cluster create \
               -p "80:80@server:*" \
               -p "443:443@server:*" \
@@ -69,6 +106,7 @@ components:
               --k3s-arg "--disable=servicelb@server:*" \
               --k3s-arg "--disable=local-storage@server:*" \
               --image ${ZARF_VAR_K3D_IMAGE} ${ZARF_VAR_K3D_EXTRA_ARGS} \
+              ${VOLUME_MOUNT} \
               ${ZARF_VAR_CLUSTER_NAME}
             description: "Create the cluster"
         onSuccess:
@@ -91,6 +129,15 @@ components:
               echo "k3d cluster delete ${ZARF_VAR_CLUSTER_NAME}"
             description: "Print out information about how to access the cluster remotely"
 
+  - name: uds-dev-stack-airgap-images
+    required: true
+    only:
+      flavor: airgap
+    description: "Load the airgap images for uds-dev-stack into Docker"
+    import:
+      path: airgap/uds-dev-stack
+      name: uds-dev-stack-airgap-images
+
   - name: uds-dev-stack
     required: true
     description: "Install MetalLB, NGINX, Minio, local-path-rwx and Ensure MachineID to meet UDS developer needs without later config changes"
@@ -109,6 +156,8 @@ components:
         namespace: uds-dev-stack
         url: https://metallb.github.io/metallb
         version: 0.14.9
+        valuesFiles:
+          - "values/metallb-values.yaml"
       - name: uds-dev-stack
         namespace: uds-dev-stack
         localPath: chart

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -75,7 +75,7 @@ components:
             setVariables:
               - name: AIRGAP_MODE
 
-  - name: create-cluster-no-airgap
+  - name: create-cluster
     required: true
     description: "Create the k3d cluster"
     actions:
@@ -93,7 +93,7 @@ components:
           - cmd: |
               VOLUME_MOUNT=""
               if [ "${ZARF_VAR_AIRGAP_MODE}" = "true" ]; then
-                echo "AIRGAP_MODE"
+                # renovate: datasource=docker depName=ghcr.io/k3d-io/k3d-tools
                 export K3D_HELPER_IMAGE_TAG=5.8.3
                 VOLUME_MOUNT="--volume k3s-airgap-images:/var/lib/rancher/k3s/agent/images"
               fi


### PR DESCRIPTION
## Description
Adds an airgap flavor for k3d.

New airgap flavor includes all of the `k3d` and `k3s` images to start the k3d cluster. These images are loaded using `docker load`. The `k3s` airgap images are mounted into the `k3d` cluster via a `docker volume` which is picked up by `k3s` when it starts in the container. This prevents the need for building a custom `k3s` image that includes those airgap images. Then all of the `uds-dev-stack` are loaded into the `k3d` cluster using `k3d image load`.

The restrictions on the `airgap` flavor is images are not swappable at deploy time so overwriting the `k3d` image is not possible. 

## Related Issue

Fixes #173 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed