### PR TITLE
fix: action tags in workflow comments

### DIFF
--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -41,7 +41,7 @@ jobs:
         run: uds run build-airgap-package --set ARCH=${{ matrix.architecture }}
 
       - name: Upload Airgap Package Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: airgap-package-${{ matrix.architecture }}
           path: ./zarf-package-uds-k3d-*.tar.zst

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,7 +40,7 @@ jobs:
         run: uds run build --set ARCH=${{ matrix.architecture }} --no-progress
       
       - name: Upload Package Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package-${{ matrix.architecture }}
           path: ./zarf-package-uds-k3d-*.tar.zst


### PR DESCRIPTION
## Description

Fixes an issue where renovate could not look up the action tag because it was missing a v.

## Related Issue

Related to https://github.com/defenseunicorns/uds-k3d/issues/15

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed