### PR TITLE
chore: update metallb to 0.15.2, fix grouping in renovate

### DIFF
--- a/airgap/uds-dev-stack/zarf.yaml
+++ b/airgap/uds-dev-stack/zarf.yaml
@@ -46,10 +46,10 @@ components:
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/nginx/nginx-unprivileged:1.28.0-alpine nginx.tar
             description: Pull the nginx image
           # renovate: datasource=docker depName=quay.io/metallb/controller
-          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/controller:v0.15.0 metallb-controller.tar
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/controller:v0.15.2 metallb-controller.tar
             description: Pull the metallb-controller image
           # renovate: datasource=docker depName=quay.io/metallb/speaker
-          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/speaker:v0.15.0 metallb-speaker.tar
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/speaker:v0.15.2 metallb-speaker.tar
             description: Pull the metallb-speaker image
           # renovate: datasource=docker depName=quay.io/frrouting/frr
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/frrouting/frr:9.1.3 frr.tar

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
     {
       "matchFileNames": [
         "chart/**",
-        "zarf.yaml"
+        "**/zarf.yaml",
+        "values/*.yaml"
       ],
       "groupName": "dev-stack",
       "commitMessageTopic": "dev-stack",

--- a/values/metallb-values.yaml
+++ b/values/metallb-values.yaml
@@ -2,12 +2,12 @@ controller:
   image:
     repository: quay.io/metallb/controller
     # renovate: datasource=docker depName=quay.io/metallb/controller
-    tag: "v0.15.0"
+    tag: "v0.15.2"
 speaker:
   image:
     repository: quay.io/metallb/speaker
     # renovate: datasource=docker depName=quay.io/metallb/speaker
-    tag: "v0.15.0"
+    tag: "v0.15.2"
   frr:
     image:
       repository: quay.io/frrouting/frr

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -155,7 +155,7 @@ components:
       - name: metallb
         namespace: uds-dev-stack
         url: https://metallb.github.io/metallb
-        version: 0.15.0
+        version: 0.15.2
         valuesFiles:
           - "values/metallb-values.yaml"
       - name: uds-dev-stack


### PR DESCRIPTION
## Description

Updates to latest metallb and fixes renovate grouping to group these PRs together in the future.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-k3d/pull/210

Fixes https://github.com/defenseunicorns/uds-k3d/pull/209

Fixes https://github.com/defenseunicorns/uds-k3d/pull/211

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed