### PR TITLE
fix: change version check to work on all systems

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -33,7 +33,7 @@ variables:
 
   - name: ADMIN_DOMAIN
     description: "Domain for admin services, defaults to `admin.DOMAIN`"
-  
+
 components:
   - name: destroy-cluster
     required: true
@@ -52,7 +52,7 @@ components:
     import:
       path: airgap/k3d
       name: k3d-airgap-images
-    
+
   - name: create-cluster-airgap
     required: true
     only:
@@ -84,7 +84,7 @@ components:
           - cmd: |
               k3d_version=$(k3d version | grep -E -o "([0-9]+\.?){3}$")
               required_version="5.7.1"
-              if ! echo "$required_version\n$k3d_version" | sort -V -C; then
+              if ! printf "$required_version\n$k3d_version" | sort -V -c 2>/dev/null; then
                 echo "This package requires a minimum k3d version of $required_version"
                 echo "Please upgrade k3d (https://k3d.io/stable/#install-current-latest-release) and try again"
                 exit 1


### PR DESCRIPTION
## Description

Switches to `-c` for sort command, which is supported on BSD/GNU sort and coreutils/busybox. Since `-c` is not silent like `-C` also added stderr suppression.

Also noticed that `echo` on some shells will not print a newline as expected, so adjusted that to use printf.

## Related Issue

Fixes https://github.com/defenseunicorns/uds-k3d/issues/214

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed