### PR TITLE
feat: add root domain to nginx config

### DIFF
--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -14,12 +14,16 @@ data:
             hostnames;
             {{- if .Values.adminDomain }}
             *.{{ .Values.adminDomain }} backend_admin;
+            {{ .Values.adminDomain }} backend_admin;
             {{- else }}
             *.admin.{{ .Values.domain }} backend_admin;
+            admin.{{ .Values.domain }} backend_admin;
             {{- end }}
             *.{{ .Values.domain }} backend_tenant;
+            {{ .Values.domain }} backend_tenant;
             {{- if .Values.customGateway | default false}}
             *.{{ .Values.customGateway.domainName }} backend_custom_gateway;
+            {{ .Values.customGateway.domainName }} backend_custom_gateway;
             {{- end }}
             {{- if .Values.passthrough.enabled | default false}}
             {{- range .Values.passthrough.subdomains }}


### PR DESCRIPTION
## Description

Adds the root/apex domain to our nginx config by default. This helps to make testing of the root domain ([ref](https://uds.defenseunicorns.com/reference/configuration/service-mesh/ingress/#root-apex-domain-configuration)) a bit easier locally.

## Related Issue

Related to https://github.com/defenseunicorns/uds-core/issues/1641

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed