### PR TITLE
chore: revert latest k3s patch versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         image: ["rancher/k3s"]
-        version: ["v1.31.10-k3s1", "v1.32.6-k3s1", "v1.33.2-k3s1"]
+        version: ["v1.31.9-k3s1", "v1.32.5-k3s1", "v1.33.1-k3s1"]
         architecture: ["amd64"]
 
     steps:

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -3,7 +3,7 @@ includes:
 
 variables:
   - name: VERSION
-    default: "v1.32.6-k3s1"
+    default: "v1.32.5-k3s1"
   - name: IMAGE_NAME
     default: "rancher/k3s"
   - name: K3D_EXTRA_ARGS

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    default: "rancher/k3s:v1.32.6-k3s1"
+    default: "rancher/k3s:v1.32.5-k3s1"
 
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"


### PR DESCRIPTION

## Description

This reverts commit 10f53a2d92584015e3c68277408f7198f365bfe2.

We have been experiencing instability in uds-core CI, specifically around health probes. This allows us to consume other updates in uds-k3d while we dig into the issue further.

## Related Issue

Example CI failures:
- https://github.com/defenseunicorns/uds-core/actions/runs/16527179194/job/46743496597?pr=1756
- https://github.com/defenseunicorns/uds-core/actions/runs/16527179134/job/46743403411?pr=1756

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed