### PR TITLE
fix: docker volume reference pwd instead of .

### DIFF
--- a/airgap/k3d/zarf.yaml
+++ b/airgap/k3d/zarf.yaml
@@ -44,6 +44,6 @@ components:
                   docker image load -i k3d-tools.tar
                   docker image load -i k3d-image.tar
                   docker volume create k3s-airgap-images
-                  docker run --rm --entrypoint /bin/sh -v k3s-airgap-images:/dest -v .:/src rancher/k3s:${ZARF_CONST_K3S_VERSION} -c "cp /src/k3s-airgap-images.tar.zst /dest"
+                  docker run --rm --entrypoint /bin/sh -v k3s-airgap-images:/dest -v $PWD:/src rancher/k3s:${ZARF_CONST_K3S_VERSION} -c "cp /src/k3s-airgap-images.tar.zst /dest"
                   rm k3d-proxy.tar k3d-tools.tar k3d-image.tar k3s-airgap-images.tar.zst
               description: Load the airgap images for k3d into Docker


### PR DESCRIPTION
## Description

Ran into an issue with docker not recognizing the format for the volume mount of ".:" and it wanted "$PWD:" instead. This fixes it so that it will properly set the volume mount reference to PWD instead of relative "."

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed