### PR TITLE
feat: add default ulimit nofile for k3d

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -19,6 +19,10 @@ variables:
     description: "K3d image to use"
     default: "rancher/k3s:v1.32.5-k3s1"
 
+  - name: K3D_ULIMIT_NOFILE
+    description: "Set ulimit for the number of files (nofile) to container runtime (Format: SOFT:HARD)"
+    default: "1048576:1048576"
+
   - name: K3D_EXTRA_ARGS
     description: "Optionally pass k3d arguments to the default"
     default: ""
@@ -101,6 +105,7 @@ components:
               -p "80:80@server:*" \
               -p "443:443@server:*" \
               --api-port 6550 \
+              --runtime-ulimit nofile="${ZARF_VAR_K3D_ULIMIT_NOFILE}" \
               --k3s-arg "--disable=traefik@server:*" \
               --k3s-arg "--disable=metrics-server@server:*" \
               --k3s-arg "--disable=servicelb@server:*" \


### PR DESCRIPTION
## Description

This PR adds an arg to set the ulimit for the number of files (nofile) along with a default value. This default value is what most systems will already be defaulting to and is safe.

The TLDR on why this is required is because the [upstream containerd systemd unit file](https://github.com/containerd/containerd/blob/main/containerd.service) [removed](https://github.com/containerd/containerd/commit/3ca39ef01608fdd44245c0173bf071682b3bfe3c) a config at some point and is depending on the default soft limit of 1024. This is failing with newer versions of uds-core (running guess now is because of the switch to ambient mode and more sockets being open). Other distributions actually kept this config in the unit file but mine (Arch btw) is using the one straight from upstream.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed