### PR TITLE
feat: make ports configurable

### DIFF
--- a/chart/templates/nginx.yaml
+++ b/chart/templates/nginx.yaml
@@ -117,9 +117,9 @@ spec:
           command: ["nginx", "-g", "daemon off;"]
           ports:
             - containerPort: 80
-              hostPort: 80
+              hostPort: {{ .Values.nginx.httpPort | default 80 }}
             - containerPort: 443
-              hostPort: 443
+              hostPort: {{ .Values.nginx.httpsPort | default 443 }}
           {{- range .Values.extraPorts }}
             - containerPort: {{ . }}
               hostPort: {{ . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,9 @@
 extraPorts: []
 
+nginx:
+  httpPort: 80
+  httpsPort: 443
+
 coreDnsOverrides: |
   rewrite stop {
     name regex (.*\.admin\.uds\.dev) admin-ingressgateway.istio-admin-gateway.svc.cluster.local answer auto

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -34,6 +34,18 @@ variables:
   - name: ADMIN_DOMAIN
     description: "Domain for admin services, defaults to `admin.DOMAIN`"
 
+  - name: API_PORT
+    description: "Kubernetes API server port for the cluster"
+    default: "6550"
+
+  - name: HTTP_PORT
+    description: "HTTP port mapping for the cluster"
+    default: "80"
+
+  - name: HTTPS_PORT
+    description: "HTTPS port mapping for the cluster"
+    default: "443"
+
 components:
   - name: destroy-cluster
     required: true
@@ -98,9 +110,9 @@ components:
                 VOLUME_MOUNT="--volume k3s-airgap-images:/var/lib/rancher/k3s/agent/images"
               fi
               k3d cluster create \
-              -p "80:80@server:*" \
-              -p "443:443@server:*" \
-              --api-port 6550 \
+              -p "${ZARF_VAR_HTTP_PORT}:80@server:*" \
+              -p "${ZARF_VAR_HTTPS_PORT}:443@server:*" \
+              --api-port ${ZARF_VAR_API_PORT} \
               --k3s-arg "--disable=traefik@server:*" \
               --k3s-arg "--disable=metrics-server@server:*" \
               --k3s-arg "--disable=servicelb@server:*" \
@@ -119,8 +131,8 @@ components:
                 namespace: kube-system
             description: "Wait for CoreDNS to be ready"
           - cmd: |
-              echo "You can access this cluster over SSH (note http redirect will redirect to port 80 instead of 8080):"
-              echo "ssh -N -L 8080:localhost:80 -L 8443:localhost:443 -L 6550:localhost:6550"
+              echo "You can access this cluster over SSH:"
+              echo "ssh -N -L ${ZARF_VAR_HTTP_PORT}:localhost:80 -L ${ZARF_VAR_HTTPS_PORT}:localhost:443 -L ${ZARF_VAR_API_PORT}:localhost:6550"
               echo
               echo "To get the kubeconfig:"
               echo "k3d kubeconfig get ${ZARF_VAR_CLUSTER_NAME}"
@@ -171,6 +183,12 @@ components:
             # Defaults contain rewrites of `*.uds.dev` to the UDS core Istio tenant and admin gateways
             description: "CoreDNS overrides"
             path: coreDnsOverrides
+          - name: HTTP_PORT
+            description: "HTTP port mapping for the cluster"
+            path: nginx.httpPort
+          - name: HTTPS_PORT
+            description: "HTTPS port mapping for the cluster"
+            path: nginx.httpsPort
       - name: minio
         namespace: uds-dev-stack
         version: 5.4.0


### PR DESCRIPTION
## Description

Makes the api, http, and https ports configurable for use by the create-cluster component. This becomes useful when attempting to deploy multiple uds-k3d clusters.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed