### PR TITLE
chore: add milestone trigger, docs-shim

### DIFF
--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -2,10 +2,23 @@ name: Test UDS Airgap Capability
 
 on:
   pull_request:
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    types: [milestoned, opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
-      - "docs/**"
-      - "CODEOWNERS"
+      - "**.jpg"
+      - "**.png"
+      - "**.gif"
+      - "**.svg"
+      - docs/**
+      - .vscode/**
+      - .gitignore
+      - renovate.json
+      - .codespellrc
+      - .release-please-config.json
+      - release-please-config.json
+      - CODEOWNERS
+      - LICENSE
   workflow_call:
 
 permissions:
@@ -32,10 +45,7 @@ jobs:
         run: |
             echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ secrets.GITHUB_TOKEN }}\"}\"" >> "GITHUB_ENV"
             uds run actions:setup-environment \
-            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
       - name: Create the airgap package

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2,10 +2,23 @@ name: Test UDS Capability
 
 on:
   pull_request:
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    types: [milestoned, opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
-      - "docs/**"
-      - "CODEOWNERS"
+      - "**.jpg"
+      - "**.png"
+      - "**.gif"
+      - "**.svg"
+      - docs/**
+      - .vscode/**
+      - .gitignore
+      - renovate.json
+      - .codespellrc
+      - .release-please-config.json
+      - release-please-config.json
+      - CODEOWNERS
+      - LICENSE
   workflow_call:
 
 permissions:
@@ -31,10 +44,7 @@ jobs:
         run: |
             echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ secrets.GITHUB_TOKEN }}\"}\"" >> "GITHUB_ENV"
             uds run actions:setup-environment \
-            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
       - name: Create uds-k3d package
@@ -68,10 +78,7 @@ jobs:
       - name: Environment setup
         run: |
             uds run actions:setup-environment \
-            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
       - name: Download Package Artifact

--- a/.github/workflows/docs-shim.yaml
+++ b/.github/workflows/docs-shim.yaml
@@ -1,0 +1,37 @@
+name: CI Docs
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    types: [milestoned, opened, reopened, synchronize]
+    paths:
+      - "**.md"
+      - "**.jpg"
+      - "**.png"
+      - "**.gif"
+      - "**.svg"
+      - docs/**
+      - .vscode/**
+      - .gitignore
+      - renovate.json
+      - .codespellrc
+      - .release-please-config.json
+      - release-please-config.json
+      - CODEOWNERS
+      - LICENSE
+
+jobs:
+  deploy-airgap:
+    name: Deploy Airgap Package
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [amd64] # Only test with amd64 for deployment
+
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -36,10 +36,7 @@ jobs:
         run: |
             echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ secrets.GITHUB_TOKEN }}\"}\"" >> "GITHUB_ENV"
             uds run actions:setup-environment \
-            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
       - name: Publish the custom k3s image

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -65,10 +65,7 @@ jobs:
         run: |
             echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ secrets.GITHUB_TOKEN }}\"}\"" >> "GITHUB_ENV"
             uds run actions:setup-environment \
-            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-            --set CHAINGUARD_IDENTITY="${{ secrets.CHAINGUARD_IDENTITY }}"
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
       - name: Download Airgap Package Artifact


### PR DESCRIPTION
## Description

A few miscellaneous housekeeping things:
- adds milestone trigger to ensure we can run required CI on releases
- removes chainguard/registry1 logins (not actually used)
- adds docs-shim workflow so that required checks run on docs only PRs, plus updates paths

## Related Issue

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed