### PR TITLE
fix!: change local-path-config directory permissions from 0777 to 0755

### DIFF
--- a/chart/templates/localpath-rwx.yaml
+++ b/chart/templates/localpath-rwx.yaml
@@ -103,7 +103,7 @@ data:
   setup: |-
     #!/bin/sh
     set -eu
-    mkdir -m 0777 -p "$VOL_DIR"
+    mkdir -m 0755 -p "$VOL_DIR"
   teardown: |-
     #!/bin/sh
     set -eu


### PR DESCRIPTION
Fixes #273

## Description
BREAKING CHANGE: changes the directory permissions for PV mounts from 777 to 755. 777 masks misconfigurations that only show up when deploying to "higher tier" environments where the permissions of mounted directories is 755 or better. This is a breaking change because what once would have succeeded will now fail, but it should have been failing all along.
...

## Related Issue

Fixes # 273

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc) Breaking bug fix

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed