### PR TITLE
feat: add custom k3s image with glibc for FIPS CNI compatibility

### DIFF
--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
         with:
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-          version: v0.27.1
+          version: v0.30.2
 
       - name: Download Zarf Init Package
         run: |
@@ -109,7 +109,7 @@ jobs:
       - name: Deploy the airgap package
         run: uds run deploy-airgap-package --no-progress
         shell: bash
-      
+
       - name: Validate uds-k3d package
         run: |
           uds run validate-airgap --no-progress

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -48,6 +48,18 @@ jobs:
             --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build k3s image for airgap packaging
+        run: |
+          K3S_VERSION=$(grep -A1 'datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s' tasks.yaml | grep 'default:' | sed 's/.*"\(.*\)".*/\1/')
+          docker buildx build \
+            --platform linux/${{ matrix.architecture }} \
+            --build-arg K3S_TAG="${K3S_VERSION}" \
+            --output "type=docker,dest=airgap/k3d/k3d-image.tar" \
+            --tag "ghcr.io/defenseunicorns/uds-k3d/k3s:${K3S_VERSION}" \
+            docker/
+
       - name: Create the airgap package
         run: uds run build-airgap-package --set ARCH=${{ matrix.architecture }}
 

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -48,6 +48,8 @@ jobs:
             --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         shell: bash
 
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Create the airgap package

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -50,16 +50,6 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Build k3s image for airgap packaging
-        run: |
-          K3S_VERSION=$(grep -A1 'datasource=github-releases depName=k3s-io/k3s' tasks.yaml | grep 'default:' | sed 's/.*"\(.*\)".*/\1/')
-          docker buildx build \
-            --platform linux/${{ matrix.architecture }} \
-            --build-arg K3S_TAG="${K3S_VERSION}" \
-            --output "type=docker,dest=airgap/k3d/k3d-image.tar" \
-            --tag "ghcr.io/defenseunicorns/uds-k3d/k3s:${K3S_VERSION}" \
-            docker/
-
       - name: Create the airgap package
         run: uds run build-airgap-package --set ARCH=${{ matrix.architecture }}
 

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -64,11 +64,11 @@ jobs:
 
   deploy-airgap:
     name: Deploy Airgap Package
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     needs: build-package # This job depends on the build-package job completing successfully
     strategy:
       matrix:
-        architecture: [amd64] # Only test with amd64 for deployment
+        architecture: [amd64, arm64]
 
     steps:
       - name: Harden Runner - Block Egress
@@ -99,7 +99,7 @@ jobs:
       - name: Download Zarf Init Package
         run: |
           ZARF_VERSION=$(uds zarf version)
-          curl -L https://github.com/zarf-dev/zarf/releases/download/${ZARF_VERSION}/zarf-init-amd64-${ZARF_VERSION}.tar.zst -o zarf-init-amd64-${ZARF_VERSION}.tar.zst
+          curl -L https://github.com/zarf-dev/zarf/releases/download/${ZARF_VERSION}/zarf-init-${{ matrix.architecture }}-${ZARF_VERSION}.tar.zst -o zarf-init-${{ matrix.architecture }}-${ZARF_VERSION}.tar.zst
 
       - name: Install deps
         run: |

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build k3s image for airgap packaging
         run: |
-          K3S_VERSION=$(grep -A1 'datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s' tasks.yaml | grep 'default:' | sed 's/.*"\(.*\)".*/\1/')
+          K3S_VERSION=$(grep -A1 'datasource=github-releases depName=k3s-io/k3s' tasks.yaml | grep 'default:' | sed 's/.*"\(.*\)".*/\1/')
           docker buildx build \
             --platform linux/${{ matrix.architecture }} \
             --build-arg K3S_TAG="${K3S_VERSION}" \

--- a/.github/workflows/airgap-build-test.yaml
+++ b/.github/workflows/airgap-build-test.yaml
@@ -93,8 +93,9 @@ jobs:
       - name: Install UDS CLI
         uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
         with:
+          # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
           version: v0.27.1
-      
+
       - name: Download Zarf Init Package
         run: |
           ZARF_VERSION=$(uds zarf version)

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -62,16 +62,9 @@ jobs:
     needs: build-package
     strategy:
       matrix:
-        image: ["rancher/k3s"]
-        version: ["v1.33.8-k3s1", "v1.34.4-k3s1", "v1.35.1-k3s1"]
+        # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
+        version: ["v1.34.4-k3s1"]
         architecture: ["amd64"]
-        include:
-          # Test the custom glibc image at the current default k3s version.
-          # This validates FIPS CNI compatibility without running all version permutations.
-          - image: "ghcr.io/defenseunicorns/uds-k3d/k3s"
-            # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
-            version: "v1.34.4-k3s1"
-            architecture: "amd64"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,22 +87,11 @@ jobs:
           name: package-${{ matrix.architecture }}
           path: .
 
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
       - name: Build the custom k3s image
-        if: ${{ matrix.image != 'rancher/k3s' }}
         run: uds run build-image --set VERSION=${{ matrix.version }} --no-progress
 
-      - name: Validate arm64 Dockerfile build
-        if: ${{ matrix.image != 'rancher/k3s' }}
-        run: |
-          docker buildx build \
-            --platform linux/arm64 \
-            --build-arg K3S_TAG=${{ matrix.version }} \
-            docker/
-
       - name: Create and deploy the uds-k3d package
-        run: uds run deploy --set IMAGE_NAME=${{ matrix.image }} --set VERSION=${{ matrix.version }} --no-progress
+        run: uds run deploy --set VERSION=${{ matrix.version }} --no-progress
 
       - name: Validate uds-k3d package
         run: uds run validate --no-progress

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        architecture: [amd64, arm64]
+        architecture: [amd64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -65,6 +65,13 @@ jobs:
         image: ["rancher/k3s"]
         version: ["v1.33.8-k3s1", "v1.34.4-k3s1", "v1.35.1-k3s1"]
         architecture: ["amd64"]
+        include:
+          # Test the custom glibc image at the current default k3s version.
+          # This validates FIPS CNI compatibility without running all version permutations.
+          - image: "ghcr.io/defenseunicorns/uds-k3d/k3s"
+            # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
+            version: "v1.34.4-k3s1"
+            architecture: "amd64"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,13 +94,22 @@ jobs:
           name: package-${{ matrix.architecture }}
           path: .
 
-      # Step is not currently being used, could be uncommented if custom image support is needed in the future
-      # - name: Build the custom k3s image
-      #   if: ${{matrix.image}} != "rancher/k3s"
-      #   run: uds run build-image --set VERSION=${{matrix.version}} --no-progress
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build the custom k3s image
+        if: ${{ matrix.image != 'rancher/k3s' }}
+        run: uds run build-image --set VERSION=${{ matrix.version }} --no-progress
+
+      - name: Validate arm64 Dockerfile build
+        if: ${{ matrix.image != 'rancher/k3s' }}
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg K3S_TAG=${{ matrix.version }} \
+            docker/
 
       - name: Create and deploy the uds-k3d package
-        run: uds run deploy --set IMAGE_NAME=${{matrix.image}} --set VERSION=${{matrix.version}} --no-progress
+        run: uds run deploy --set IMAGE_NAME=${{ matrix.image }} --set VERSION=${{ matrix.version }} --no-progress
 
       - name: Validate uds-k3d package
         run: uds run validate --no-progress

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        architecture: [amd64]
+        architecture: [amd64, arm64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -58,13 +58,13 @@ jobs:
           retention-days: 1
 
   test-clean-install:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     needs: build-package
     strategy:
       matrix:
         # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
         version: ["v1.34.4-k3s1"]
-        architecture: ["amd64"]
+        architecture: ["amd64", "arm64"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -88,10 +88,10 @@ jobs:
           path: .
 
       - name: Build the custom k3s image
-        run: uds run build-image --set VERSION=${{ matrix.version }} --no-progress
+        run: uds run build-image --set VERSION=${{ matrix.version }} --set ARCH=${{ matrix.architecture }} --no-progress
 
       - name: Create and deploy the uds-k3d package
-        run: uds run deploy --set VERSION=${{ matrix.version }} --no-progress
+        run: uds run deploy --set VERSION=${{ matrix.version }} --set ARCH=${{ matrix.architecture }} --no-progress
 
       - name: Validate uds-k3d package
         run: uds run validate --no-progress

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,30 +1,37 @@
 name: Publish k3s image
 
-# Workflow is not currently being used, switched to a manual trigger only
-on: workflow_dispatch
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - docker/**
-  #     - .github/workflows/publish-image.yaml
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docker/**
+      - .github/workflows/publish-image.yaml
+  workflow_dispatch:
 
 jobs:
   publish-k3s-image:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v1.2.3-k3s1"] # Placeholder
+        # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
+        version: ["v1.34.4-k3s1"]
 
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install UDS CLI
         uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to GHCR

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ package:
 ### Additional Details and Documentation
 
 - [UDS Dev Stack](docs/DEV-STACK.md)
+- [Custom k3s Image](docs/CUSTOM-K3S-IMAGE.md)
 - [Configuring Minio](docs/MINIO.md)
 - [DNS Assumptions](docs/DNS.md)
 - [Airgap](docs/AIRGAP.md)

--- a/airgap/k3d/zarf.yaml
+++ b/airgap/k3d/zarf.yaml
@@ -45,11 +45,11 @@ components:
             description: Download the airgap 'k3s' images
       onDeploy:
         after:
-            - cmd: |
-                  docker image load -i k3d-proxy.tar
-                  docker image load -i k3d-tools.tar
-                  docker image load -i k3d-image.tar
-                  docker volume create k3s-airgap-images
-                  docker run --rm --entrypoint /bin/sh -v k3s-airgap-images:/dest -v $PWD:/src ghcr.io/defenseunicorns/uds-k3d/k3s:${ZARF_CONST_K3S_VERSION} -c "cp /src/k3s-airgap-images.tar.zst /dest"
-                  rm k3d-proxy.tar k3d-tools.tar k3d-image.tar k3s-airgap-images.tar.zst
-              description: Load the airgap images for k3d into Docker
+          - cmd: |
+              docker image load -i k3d-proxy.tar
+              docker image load -i k3d-tools.tar
+              docker image load -i k3d-image.tar
+              docker volume create k3s-airgap-images
+              docker run --rm --entrypoint /bin/sh -v k3s-airgap-images:/dest -v $PWD:/src ghcr.io/defenseunicorns/uds-k3d/k3s:${ZARF_CONST_K3S_VERSION} -c "cp /src/k3s-airgap-images.tar.zst /dest"
+              rm k3d-proxy.tar k3d-tools.tar k3d-image.tar k3s-airgap-images.tar.zst
+            description: Load the airgap images for k3d into Docker

--- a/airgap/k3d/zarf.yaml
+++ b/airgap/k3d/zarf.yaml
@@ -32,10 +32,13 @@ components:
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/k3d-io/k3d-tools:5.8.3 k3d-tools.tar
             description: Pull the 'k3d-tools' image
           - cmd: |
-              if [ ! -f k3d-image.tar ]; then
-                ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/defenseunicorns/uds-k3d/k3s:"###ZARF_PKG_TMPL_K3S_VERSION###" k3d-image.tar
-              fi
-            description: Pull the airgap 'k3s' image
+              docker buildx build \
+                --platform linux/"###ZARF_PKG_ARCH###" \
+                --build-arg K3S_TAG="###ZARF_PKG_TMPL_K3S_VERSION###" \
+                --output "type=docker,dest=k3d-image.tar" \
+                --tag "ghcr.io/defenseunicorns/uds-k3d/k3s:###ZARF_PKG_TMPL_K3S_VERSION###" \
+                ../../docker/
+            description: Build the custom k3s image
           - cmd: |
               K3S_AIRGAP_IMAGES=$(echo "###ZARF_PKG_TMPL_K3S_VERSION###" | sed 's/-k3s/%2Bk3s/g')
               curl -L https://github.com/k3s-io/k3s/releases/download/"${K3S_AIRGAP_IMAGES}"/k3s-airgap-images-"###ZARF_PKG_ARCH###".tar.zst -o k3s-airgap-images.tar.zst

--- a/airgap/k3d/zarf.yaml
+++ b/airgap/k3d/zarf.yaml
@@ -31,7 +31,10 @@ components:
           # renovate: datasource=docker depName=ghcr.io/k3d-io/k3d-tools
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/k3d-io/k3d-tools:5.8.3 k3d-tools.tar
             description: Pull the 'k3d-tools' image
-          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/defenseunicorns/uds-k3d/k3s:"###ZARF_PKG_TMPL_K3S_VERSION###" k3d-image.tar
+          - cmd: |
+              if [ ! -f k3d-image.tar ]; then
+                ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/defenseunicorns/uds-k3d/k3s:"###ZARF_PKG_TMPL_K3S_VERSION###" k3d-image.tar
+              fi
             description: Pull the airgap 'k3s' image
           - cmd: |
               K3S_AIRGAP_IMAGES=$(echo "###ZARF_PKG_TMPL_K3S_VERSION###" | sed 's/-k3s/%2Bk3s/g')

--- a/airgap/k3d/zarf.yaml
+++ b/airgap/k3d/zarf.yaml
@@ -31,7 +31,7 @@ components:
           # renovate: datasource=docker depName=ghcr.io/k3d-io/k3d-tools
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/k3d-io/k3d-tools:5.8.3 k3d-tools.tar
             description: Pull the 'k3d-tools' image
-          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" rancher/k3s:"###ZARF_PKG_TMPL_K3S_VERSION###" k3d-image.tar
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" ghcr.io/defenseunicorns/uds-k3d/k3s:"###ZARF_PKG_TMPL_K3S_VERSION###" k3d-image.tar
             description: Pull the airgap 'k3s' image
           - cmd: |
               K3S_AIRGAP_IMAGES=$(echo "###ZARF_PKG_TMPL_K3S_VERSION###" | sed 's/-k3s/%2Bk3s/g')
@@ -44,6 +44,6 @@ components:
                   docker image load -i k3d-tools.tar
                   docker image load -i k3d-image.tar
                   docker volume create k3s-airgap-images
-                  docker run --rm --entrypoint /bin/sh -v k3s-airgap-images:/dest -v $PWD:/src rancher/k3s:${ZARF_CONST_K3S_VERSION} -c "cp /src/k3s-airgap-images.tar.zst /dest"
+                  docker run --rm --entrypoint /bin/sh -v k3s-airgap-images:/dest -v $PWD:/src ghcr.io/defenseunicorns/uds-k3d/k3s:${ZARF_CONST_K3S_VERSION} -c "cp /src/k3s-airgap-images.tar.zst /dest"
                   rm k3d-proxy.tar k3d-tools.tar k3d-image.tar k3s-airgap-images.tar.zst
               description: Load the airgap images for k3d into Docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# Custom k3s image with glibc and OpenSSL for FIPS CNI compatibility.
+#
+# The default rancher/k3s image is Alpine-based (musl libc). FIPS CNI plugins
+# (e.g. istio-install-cni-fips from cgr.dev) are dynamically linked against glibc
+# and require dlopen("libcrypto.so.3") at runtime via Go's opensslcrypto backend.
+#
+# We keep the Alpine k3s base intact and copy only the required glibc and OpenSSL
+# libraries from cgr.dev/chainguard/wolfi-base (free, publicly accessible).
+# Wolfi places libs in /usr/lib/ (no arch-specific subdir), which is a default
+# search path for the glibc dynamic linker.
+
+# K3S_TAG has no default — callers must pass --build-arg K3S_TAG=<version>.
+ARG K3S_TAG
+# Pinned to a digest for reproducible builds. Renovate manages this via the
+# built-in Docker manager (ARG followed by FROM ${VAR} pattern).
+ARG WOLFI_IMAGE="cgr.dev/chainguard/wolfi-base:latest@sha256:1af610c4a70668dad46159ee178b20378c79a49b554f76405670fc442d30183a"
+
+FROM ${WOLFI_IMAGE} AS wolfi
+FROM rancher/k3s:${K3S_TAG}
+
+# Copy glibc runtime libraries from Wolfi.
+# The ELF interpreter filename differs by architecture (ld-linux-x86-64.so.2 vs
+# ld-linux-aarch64.so.1), so use a glob to pick up whichever the platform ships.
+COPY --from=wolfi /usr/lib/ld-linux-*.so* /usr/lib/
+# libdl.so.2 and libpthread.so.0 are compat stubs since glibc 2.34 (both merged
+# into libc.so.6). Included for backward compatibility with binaries that link
+# against them explicitly.
+COPY --from=wolfi \
+    /usr/lib/libc.so.6 \
+    /usr/lib/libdl.so.2 \
+    /usr/lib/libpthread.so.0 \
+    /usr/lib/
+
+# Copy OpenSSL — Go's opensslcrypto backend calls dlopen("libcrypto.so.3") at runtime.
+# libcrypto.so.3 depends only on libc.so.6 (verified via readelf -d).
+COPY --from=wolfi /usr/lib/libcrypto.so.3 /usr/lib/
+
+# Create the ELF interpreter symlinks that glibc-linked binaries expect.
+# Symlink paths differ by architecture:
+#   amd64: /lib64/ld-linux-x86-64.so.2 and /lib/ld-linux-x86-64.so.2
+#   arm64: /lib/ld-linux-aarch64.so.1 (no /lib64 convention on arm64)
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+    amd64) \
+        mkdir -p /lib64 && \
+        ln -sf /usr/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 && \
+        ln -sf /usr/lib/ld-linux-x86-64.so.2 /lib/ld-linux-x86-64.so.2 \
+        ;; \
+    arm64) \
+        ln -sf /usr/lib/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1 \
+        ;; \
+    *) echo "Unsupported architecture: ${TARGETARCH}" >&2 && exit 1 ;; \
+    esac
+
+# Verify the glibc dynamic linker is functional and libcrypto is present.
+# Catches broken symlinks or missing libraries at build time rather than at
+# runtime in the cluster.
+RUN /usr/lib/ld-linux-*.so* --version 2>&1 | grep -qi "glibc" || \
+    (echo "ERROR: glibc ELF interpreter not functional" >&2 && exit 1)
+RUN test -f /usr/lib/libcrypto.so.3 || \
+    (echo "ERROR: libcrypto.so.3 not found" >&2 && exit 1)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,47 +1,27 @@
 # Copyright 2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-# Custom k3s image with glibc and OpenSSL for FIPS CNI compatibility.
-#
-# The default rancher/k3s image is Alpine-based (musl libc). FIPS CNI plugins
-# (e.g. istio-install-cni-fips from cgr.dev) are dynamically linked against glibc
-# and require dlopen("libcrypto.so.3") at runtime via Go's opensslcrypto backend.
-#
-# We keep the Alpine k3s base intact and copy only the required glibc and OpenSSL
-# libraries from cgr.dev/chainguard/wolfi-base (free, publicly accessible).
-# Wolfi places libs in /usr/lib/ (no arch-specific subdir), which is a default
-# search path for the glibc dynamic linker.
-
-# K3S_TAG has no default — callers must pass --build-arg K3S_TAG=<version>.
+# K3S_TAG has no default; callers must pass --build-arg K3S_TAG=<version>.
 ARG K3S_TAG
-# Pinned to a digest for reproducible builds. Renovate manages this via the
-# built-in Docker manager (ARG followed by FROM ${VAR} pattern).
+# Digest-pinned for reproducible builds; managed by Renovate's Docker manager.
 ARG WOLFI_IMAGE="cgr.dev/chainguard/wolfi-base:latest@sha256:1af610c4a70668dad46159ee178b20378c79a49b554f76405670fc442d30183a"
 
 FROM ${WOLFI_IMAGE} AS wolfi
 FROM rancher/k3s:${K3S_TAG}
 
-# Copy glibc runtime libraries from Wolfi.
-# The ELF interpreter filename differs by architecture (ld-linux-x86-64.so.2 vs
-# ld-linux-aarch64.so.1), so use a glob to pick up whichever the platform ships.
+# Glob picks up the arch-specific ELF interpreter (ld-linux-x86-64.so.2 or ld-linux-aarch64.so.1).
 COPY --from=wolfi /usr/lib/ld-linux-*.so* /usr/lib/
-# libdl.so.2 and libpthread.so.0 are compat stubs since glibc 2.34 (both merged
-# into libc.so.6). Included for backward compatibility with binaries that link
-# against them explicitly.
+# libdl.so.2 and libpthread.so.0 are compat stubs since glibc 2.34; included for
+# binaries that still link against them explicitly.
 COPY --from=wolfi \
     /usr/lib/libc.so.6 \
     /usr/lib/libdl.so.2 \
     /usr/lib/libpthread.so.0 \
     /usr/lib/
 
-# Copy OpenSSL — Go's opensslcrypto backend calls dlopen("libcrypto.so.3") at runtime.
-# libcrypto.so.3 depends only on libc.so.6 (verified via readelf -d).
+# libcrypto.so.3 is not a static ELF dependency; Go's opensslcrypto backend dlopen's it at runtime.
 COPY --from=wolfi /usr/lib/libcrypto.so.3 /usr/lib/
 
-# Create the ELF interpreter symlinks that glibc-linked binaries expect.
-# Symlink paths differ by architecture:
-#   amd64: /lib64/ld-linux-x86-64.so.2 and /lib/ld-linux-x86-64.so.2
-#   arm64: /lib/ld-linux-aarch64.so.1 (no /lib64 convention on arm64)
 ARG TARGETARCH
 RUN case "${TARGETARCH}" in \
     amd64) \
@@ -55,9 +35,6 @@ RUN case "${TARGETARCH}" in \
     *) echo "Unsupported architecture: ${TARGETARCH}" >&2 && exit 1 ;; \
     esac
 
-# Verify the glibc dynamic linker is functional and libcrypto is present.
-# Catches broken symlinks or missing libraries at build time rather than at
-# runtime in the cluster.
 RUN /usr/lib/ld-linux-*.so* --version 2>&1 | grep -qi "glibc" || \
     (echo "ERROR: glibc ELF interpreter not functional" >&2 && exit 1)
 RUN test -f /usr/lib/libcrypto.so.3 || \

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -4,7 +4,7 @@
 
 ## Why It Exists
 
-The standard `rancher/k3s` image is Alpine-based and uses musl libc. FIPS CNI plugins — such as `istio-install-cni-fips` from Chainguard — are dynamically linked against glibc and require the glibc ELF interpreter (`ld-linux-*.so`) plus `libcrypto.so.3` (loaded at runtime via Go's opensslcrypto backend). On a musl-only image, these binaries fail to start.
+The standard `rancher/k3s` image is Alpine-based and uses musl libc. FIPS CNI plugins such as `istio-install-cni-fips` are dynamically linked against glibc and require the glibc ELF interpreter (`ld-linux-*.so`) plus `libcrypto.so.3` (loaded at runtime via Go's opensslcrypto backend). On a musl-only image, these binaries fail to start.
 
 The custom image solves this by keeping the Alpine k3s base intact and copying only the required libraries from `cgr.dev/chainguard/wolfi-base` (a free, publicly accessible Chainguard image). No Alpine packages are modified or replaced.
 
@@ -12,11 +12,11 @@ Libraries added:
 
 | Library | Purpose |
 |---|---|
-| `ld-linux-*.so` | glibc ELF interpreter — required to exec glibc-linked binaries |
+| `ld-linux-*.so` | glibc ELF interpreter, required to exec glibc-linked binaries |
 | `libc.so.6` | glibc C runtime |
 | `libdl.so.2` | compat stub (merged into libc since glibc 2.34) |
 | `libpthread.so.0` | compat stub (merged into libc since glibc 2.34) |
-| `libcrypto.so.3` | OpenSSL — dlopen'd at runtime by Go's opensslcrypto backend |
+| `libcrypto.so.3` | OpenSSL, dlopen'd at runtime by Go's opensslcrypto backend |
 
 ELF interpreter symlinks are created at the conventional paths expected by glibc-linked binaries:
 
@@ -45,7 +45,7 @@ uds run publish-image --set VERSION=<k3s-version>
 
 k3s version bumps require two separate Renovate PRs in sequence:
 
-1. **`k3s-image` group PR** — updates the k3s version in `publish-image.yaml` and `build-test.yaml`. When merged, CI rebuilds and publishes the new image to GHCR.
-2. **Second `k3s-image` group PR** — updates `zarf.yaml`, `airgap/k3d/zarf.yaml`, and `tasks.yaml` to reference the newly published image.
+1. **`k3s-image` group PR**: updates the k3s version in `publish-image.yaml` and `build-test.yaml`. When merged, CI rebuilds and publishes the new image to GHCR.
+2. **Second `k3s-image` group PR**: updates `zarf.yaml`, `airgap/k3d/zarf.yaml`, and `tasks.yaml` to reference the newly published image.
 
 The `tasks.yaml` `VERSION` variable carries a `datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s` Renovate annotation so Renovate updates it only after the new image is available in GHCR.

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -43,9 +43,10 @@ uds run publish-image --set VERSION=<k3s-version>
 
 ## Renovate Updates
 
-k3s version bumps use a two-PR flow:
+This repo intentionally stays n-1 on k3s (one minor version behind latest). The `allowedVersions: "<1.35"` constraint in `renovate.json` enforces this; update it manually when adopting a new minor version.
 
-1. **`k3s-image` group PR**: updates `publish-image.yaml`, `build-test.yaml`, and `tasks.yaml` together (all use `datasource=github-releases depName=k3s-io/k3s`). CI builds the image locally so the PR passes without GHCR. When merged, `publish-image.yaml` triggers and publishes the new image to GHCR.
-2. **Second `k3s-image` group PR**: updates `zarf.yaml`'s `K3D_IMAGE` default once the new Docker image is available in GHCR. This is cosmetic; it only affects users deploying directly from the OCI package without overriding `K3D_IMAGE`.
+All k3s references track the upstream `k3s-io/k3s` GitHub releases directly, so version bumps come in a **single PR** that updates `tasks.yaml`, `build-test.yaml`, and `zarf.yaml`'s `K3D_IMAGE` default together. CI passes because both the connected and airgap builds construct the custom image locally, with no GHCR pull during CI. After the PR merges, `publish-image.yaml` triggers and publishes the new image to GHCR.
 
-The airgap package (`airgap/k3d/zarf.yaml`) has no separate version annotation. It builds the custom k3s image locally during `zarf package create` using the version passed via `--set K3S_VERSION` from `tasks.yaml`, so it picks up Phase 1 version bumps immediately without a GHCR dependency.
+The airgap package builds the custom k3s image locally during `zarf package create` using the version from `tasks.yaml`, so it has no GHCR dependency at package creation time.
+
+`cgr.dev/chainguard/wolfi-base` (the glibc source) is grouped with k3s in Renovate since it directly affects the published image artifact.

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -48,4 +48,4 @@ k3s version bumps use a two-PR flow:
 1. **`k3s-image` group PR**: updates `publish-image.yaml`, `build-test.yaml`, and `tasks.yaml` together (all use `datasource=github-releases depName=k3s-io/k3s`). CI builds the image locally so the PR passes without GHCR. When merged, `publish-image.yaml` triggers and publishes the new image to GHCR.
 2. **Second `k3s-image` group PR**: updates `zarf.yaml`'s `K3D_IMAGE` default once the new Docker image is available in GHCR. This is cosmetic; it only affects users deploying directly from the OCI package without overriding `K3D_IMAGE`.
 
-`airgap/k3d/zarf.yaml` has no separate version annotation; it receives the version at package create time via `--set K3S_VERSION` from `tasks.yaml`.
+The airgap package (`airgap/k3d/zarf.yaml`) has no separate version annotation. It builds the custom k3s image locally during `zarf package create` using the version passed via `--set K3S_VERSION` from `tasks.yaml`, so it picks up Phase 1 version bumps immediately without a GHCR dependency.

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -46,6 +46,6 @@ uds run publish-image --set VERSION=<k3s-version>
 k3s version bumps require two separate Renovate PRs in sequence:
 
 1. **`k3s-image` group PR** — updates the k3s version in `publish-image.yaml` and `build-test.yaml`. When merged, CI rebuilds and publishes the new image to GHCR.
-2. **`dev-stack` group PR** — updates `zarf.yaml` and `airgap/k3d/zarf.yaml` to reference the newly published image.
+2. **Second `k3s-image` group PR** — updates `zarf.yaml`, `airgap/k3d/zarf.yaml`, and `tasks.yaml` to reference the newly published image.
 
 The `tasks.yaml` `VERSION` variable carries a `datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s` Renovate annotation so Renovate updates it only after the new image is available in GHCR.

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -43,9 +43,9 @@ uds run publish-image --set VERSION=<k3s-version>
 
 ## Renovate Updates
 
-k3s version bumps require two separate Renovate PRs in sequence:
+k3s version bumps use a two-PR flow:
 
-1. **`k3s-image` group PR**: updates the k3s version in `publish-image.yaml` and `build-test.yaml`. When merged, CI rebuilds and publishes the new image to GHCR.
-2. **Second `k3s-image` group PR**: updates `zarf.yaml`, `airgap/k3d/zarf.yaml`, and `tasks.yaml` to reference the newly published image.
+1. **`k3s-image` group PR**: updates `publish-image.yaml`, `build-test.yaml`, and `tasks.yaml` together (all use `datasource=github-releases depName=k3s-io/k3s`). CI builds the image locally so the PR passes without GHCR. When merged, `publish-image.yaml` triggers and publishes the new image to GHCR.
+2. **Second `k3s-image` group PR**: updates `zarf.yaml`'s `K3D_IMAGE` default once the new Docker image is available in GHCR. This is cosmetic; it only affects users deploying directly from the OCI package without overriding `K3D_IMAGE`.
 
-The `tasks.yaml` `VERSION` variable carries a `datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s` Renovate annotation so Renovate updates it only after the new image is available in GHCR.
+`airgap/k3d/zarf.yaml` has no separate version annotation; it receives the version at package create time via `--set K3S_VERSION` from `tasks.yaml`.

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -43,7 +43,7 @@ uds run publish-image --set VERSION=<k3s-version>
 
 ## Renovate Updates
 
-This repo intentionally stays n-1 on k3s (one minor version behind latest). The `allowedVersions: "<1.35"` constraint in `renovate.json` enforces this; update it manually when adopting a new minor version.
+This repo intentionally stays n-1 on k3s (one minor version behind latest). The `allowedVersions: "<1.36"` constraint in `renovate.json` enforces this; update it manually when adopting a new minor version.
 
 All k3s references track the upstream `k3s-io/k3s` GitHub releases directly, so version bumps come in a **single PR** that updates `tasks.yaml`, `build-test.yaml`, and `zarf.yaml`'s `K3D_IMAGE` default together. CI passes because both the connected and airgap builds construct the custom image locally, with no GHCR pull during CI. After the PR merges, `publish-image.yaml` triggers and publishes the new image to GHCR.
 

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -1,0 +1,51 @@
+# Custom k3s Image
+
+`uds-k3d` publishes a custom k3s image at `ghcr.io/defenseunicorns/uds-k3d/k3s` that extends the standard `rancher/k3s` image with glibc and OpenSSL libraries. This image is the default for `uds-k3d` deployments.
+
+## Why It Exists
+
+The standard `rancher/k3s` image is Alpine-based and uses musl libc. FIPS CNI plugins — such as `istio-install-cni-fips` from Chainguard — are dynamically linked against glibc and require the glibc ELF interpreter (`ld-linux-*.so`) plus `libcrypto.so.3` (loaded at runtime via Go's opensslcrypto backend). On a musl-only image, these binaries fail to start.
+
+The custom image solves this by keeping the Alpine k3s base intact and copying only the required libraries from `cgr.dev/chainguard/wolfi-base` (a free, publicly accessible Chainguard image). No Alpine packages are modified or replaced.
+
+Libraries added:
+
+| Library | Purpose |
+|---|---|
+| `ld-linux-*.so` | glibc ELF interpreter — required to exec glibc-linked binaries |
+| `libc.so.6` | glibc C runtime |
+| `libdl.so.2` | compat stub (merged into libc since glibc 2.34) |
+| `libpthread.so.0` | compat stub (merged into libc since glibc 2.34) |
+| `libcrypto.so.3` | OpenSSL — dlopen'd at runtime by Go's opensslcrypto backend |
+
+ELF interpreter symlinks are created at the conventional paths expected by glibc-linked binaries:
+
+- amd64: `/lib64/ld-linux-x86-64.so.2` and `/lib/ld-linux-x86-64.so.2`
+- arm64: `/lib/ld-linux-aarch64.so.1`
+
+## Building Locally
+
+```bash
+uds run build-image --set VERSION=<k3s-version>
+# e.g.
+uds run build-image --set VERSION=v1.34.4-k3s1
+```
+
+This builds a single-platform image tagged `ghcr.io/defenseunicorns/uds-k3d/k3s:<version>` for the local architecture.
+
+## Publishing
+
+CI publishes a multi-platform image (`linux/amd64` and `linux/arm64`) to GHCR when changes to `docker/**` or `.github/workflows/publish-image.yaml` are merged to `main`:
+
+```bash
+uds run publish-image --set VERSION=<k3s-version>
+```
+
+## Renovate Updates
+
+k3s version bumps require two separate Renovate PRs in sequence:
+
+1. **`k3s-image` group PR** — updates the k3s version in `publish-image.yaml` and `build-test.yaml`. When merged, CI rebuilds and publishes the new image to GHCR.
+2. **`dev-stack` group PR** — updates `zarf.yaml` and `airgap/k3d/zarf.yaml` to reference the newly published image.
+
+The `tasks.yaml` `VERSION` variable carries a `datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s` Renovate annotation so Renovate updates it only after the new image is available in GHCR.

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
     {
       "matchPackageNames": ["k3s-io/k3s"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
-      "allowedVersions": "<1.35"
+      "allowedVersions": "<1.36"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,8 @@
       "matchFileNames": [
         ".github/workflows/**",
         ".github/actions/**",
-        "tasks.yaml"
+        "tasks.yaml",
+        "docker/Dockerfile"
       ],
       "groupName": "support-deps",
       "commitMessageTopic": "support-deps"

--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,7 @@
       "matchFileNames": [
         ".github/workflows/**",
         ".github/actions/**",
-        "tasks.yaml",
-        "docker/Dockerfile"
+        "tasks.yaml"
       ],
       "groupName": "support-deps",
       "commitMessageTopic": "support-deps"
@@ -30,23 +29,17 @@
       "groupName": "dev-stack",
       "commitMessageTopic": "dev-stack",
       "matchPackageNames": [
-        "!ghcr.io/defenseunicorns/uds-k3d/k3s",
+        "!k3s-io/k3s",
         "!defenseunicorns/uds-common"
       ]
     },
     {
       "matchPackageNames": [
-        "k3s-io/k3s"
+        "k3s-io/k3s",
+        "cgr.dev/chainguard/wolfi-base"
       ],
-      "groupName": "k3s-upstream",
-      "commitMessageTopic": "k3s-upstream"
-    },
-    {
-      "matchPackageNames": [
-        "ghcr.io/defenseunicorns/uds-k3d/k3s"
-      ],
-      "groupName": "k3s-image",
-      "commitMessageTopic": "k3s-image"
+      "groupName": "k3s",
+      "commitMessageTopic": "k3s"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,10 @@
         "tasks.yaml"
       ],
       "groupName": "support-deps",
-      "commitMessageTopic": "support-deps"
+      "commitMessageTopic": "support-deps",
+      "matchPackageNames": [
+        "!k3s-io/k3s"
+      ]
     },
     {
       "matchFileNames": [
@@ -40,6 +43,22 @@
       ],
       "groupName": "k3s",
       "commitMessageTopic": "k3s"
+    },
+    {
+      "matchPackageNames": ["k3s-io/k3s"],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
+      "allowedVersions": "<1.35"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)zarf\\.yaml$"],
+      "matchStrings": [
+        "# renovate-tag: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n(?<indent>\\s+)default: \"(?<prefix>[^:]+):(?<currentValue>[^\"]+)\""
+      ],
+      "versioningTemplate": "{{{versioning}}}",
+      "autoReplaceStringTemplate": "# renovate-tag: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n{{{indent}}}default: \"{{{prefix}}}:{{{replace '\\+k3s' '-k3s' newValue}}}\""
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,9 +29,17 @@
       "groupName": "dev-stack",
       "commitMessageTopic": "dev-stack",
       "matchPackageNames": [
-        "!rancher/k3s",
+        "!ghcr.io/defenseunicorns/uds-k3d/k3s",
         "!defenseunicorns/uds-common"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "k3s-io/k3s",
+        "ghcr.io/defenseunicorns/uds-k3d/k3s"
+      ],
+      "groupName": "k3s-image",
+      "commitMessageTopic": "k3s-image"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,13 @@
     },
     {
       "matchPackageNames": [
-        "k3s-io/k3s",
+        "k3s-io/k3s"
+      ],
+      "groupName": "k3s-upstream",
+      "commitMessageTopic": "k3s-upstream"
+    },
+    {
+      "matchPackageNames": [
         "ghcr.io/defenseunicorns/uds-k3d/k3s"
       ],
       "groupName": "k3s-image",

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -3,9 +3,10 @@ includes:
 
 variables:
   - name: VERSION
+    # renovate: datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s versioning=docker
     default: "v1.34.4-k3s1"
   - name: IMAGE_NAME
-    default: "rancher/k3s"
+    default: "ghcr.io/defenseunicorns/uds-k3d/k3s"
   - name: K3D_EXTRA_ARGS
     default: ""
   - name: NGINX_EXTRA_PORTS
@@ -27,6 +28,27 @@ tasks:
       - task: build-airgap-package
       - task: deploy-airgap-package
       - task: validate # Note: for local usage this pulls zarf init
+
+  - name: build-image
+    description: "Build the custom k3s image with glibc support for FIPS CNI compatibility"
+    actions:
+      - description: "Build custom k3s image"
+        cmd: |
+          docker build \
+            --build-arg K3S_TAG=${VERSION} \
+            --tag ${IMAGE_NAME}:${VERSION} \
+            docker/
+
+  - name: publish-image
+    description: "Publish the custom k3s image (multi-platform) to the registry"
+    actions:
+      - description: "Publish custom k3s image"
+        cmd: |
+          docker buildx build --push \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg K3S_TAG=${VERSION} \
+            --tag ${IMAGE_NAME}:${VERSION} \
+            docker/
 
   - name: build
     description: "Build uds-k3d"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -3,7 +3,7 @@ includes:
 
 variables:
   - name: VERSION
-    # renovate: datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s versioning=docker
+    # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
     default: "v1.34.4-k3s1"
   - name: IMAGE_NAME
     default: "ghcr.io/defenseunicorns/uds-k3d/k3s"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -35,6 +35,7 @@ tasks:
       - description: "Build custom k3s image"
         cmd: |
           docker build \
+            --platform linux/${ARCH} \
             --build-arg K3S_TAG=${VERSION} \
             --tag ${IMAGE_NAME}:${VERSION} \
             docker/

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
+    # renovate-tag: datasource=github-releases depName=k3s-io/k3s versioning=semver
     default: "ghcr.io/defenseunicorns/uds-k3d/k3s:v1.34.4-k3s1"
 
   - name: K3D_ULIMIT_NOFILE

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    # renovate: datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s versioning=docker
+    # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
     default: "ghcr.io/defenseunicorns/uds-k3d/k3s:v1.34.4-k3s1"
 
   - name: K3D_ULIMIT_NOFILE

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,8 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    default: "rancher/k3s:v1.34.4-k3s1"
+    # renovate: datasource=docker depName=ghcr.io/defenseunicorns/uds-k3d/k3s versioning=docker
+    default: "ghcr.io/defenseunicorns/uds-k3d/k3s:v1.34.4-k3s1"
 
   - name: K3D_ULIMIT_NOFILE
     description: "Set ulimit for the number of files (nofile) to container runtime (Format: SOFT:HARD)"


### PR DESCRIPTION
## Description
FIPS CNI plugins (e.g. `istio-install-cni-fips`) are glibc-linked but `rancher/k3s` is
Alpine-based (musl libc). The CNI binary fails at exec time because the glibc ELF
interpreter doesn't exist and the OS can't load it.

This PR introduces a custom k3s image (`ghcr.io/defenseunicorns/uds-k3d/k3s`) that keeps
the Alpine k3s base intact and injects only the required glibc and OpenSSL libraries from
`cgr.dev/chainguard/wolfi-base`. The custom image becomes the new default for uds-k3d
deployments.

## Changes

- `docker/Dockerfile`: multi-stage build that copies `ld-linux`, `libc.so.6`, `libdl.so.2`,
  `libpthread.so.0`, and `libcrypto.so.3` from Wolfi; creates ELF interpreter symlinks at
  the paths glibc-linked binaries expect; smoke tests both at build time
- `tasks.yaml`: adds `build-image` (local, single-platform) and `publish-image`
  (multi-platform push) tasks; `IMAGE_NAME` variable added for the custom image
- `zarf.yaml` / `airgap/k3d/zarf.yaml`: `K3D_IMAGE` default updated to the custom image
- `publish-image.yaml`: enabled push trigger on `docker/**`; added GHCR login; pinned
  version with Renovate annotation
- `build-test.yaml`: adds a matrix entry for the custom image; builds and validates it before deploy
- `airgap-build-test.yaml`: builds the custom image locally during the build-package job
  and exports it to `airgap/k3d/k3d-image.tar` rather than pulling from GHCR (which doesn't
  exist until the PR merges); the pull step in `airgap/k3d/zarf.yaml` is now conditional so
  it skips if the file is already present
- `renovate.json`: adds `k3s-image` group to isolate k3s version bumps into their own PRs;
  adds `docker/Dockerfile` to `support-deps` so Wolfi digest bumps are grouped with other
  infra deps. k3s version bumps follow a two-phase flow: the first PR updates
  `publish-image.yaml`, `build-test.yaml`, and `tasks.yaml` together and triggers image
  publishing on merge; the second PR updates `zarf.yaml`'s `K3D_IMAGE` default once the
  image is available in GHCR
- `docs/CUSTOM-K3S-IMAGE.md`: documents the image, the libraries added, local build steps,
  publishing, and the Renovate two-phase update flow

## Testing

Requires a local uds-core checkout with a slim-dev bundle already built.

```bash
# 1. Build the custom k3s image and deploy the cluster
cd ~/path/to/uds-k3d
uds run build-image
uds run deploy

# 2. Confirm the cluster node is using the custom image
docker inspect k3d-uds-server-0 | grep Image

# 3. Deploy slim-dev but skip the k3d bundle package
# The bundle includes uds-k3d-dev from published OCI which would recreate
# the cluster with the old default image if not skipped.
cd ~/path/to/uds-core
uds deploy bundles/k3d-slim-dev/uds-bundle-k3d-slim-dev-*.tar.zst \
  --packages init,core-base,core-identity-authorization \
  --confirm

# 4. Confirm FIPS CNI pods are healthy
kubectl get pods -n istio-system
kubectl describe pod -n istio-system -l app=istio-cni-node | grep Image
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed