### PR TITLE
fix: convert k3s renovate to docker datasource

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -62,7 +62,7 @@ jobs:
     needs: build-package
     strategy:
       matrix:
-        # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
+        # renovate: datasource=docker depName=rancher/k3s versioning=semver
         version: ["v1.34.4-k3s1"]
         architecture: ["amd64", "arm64"]
 

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
+        # renovate: datasource=docker depName=rancher/k3s versioning=semver
         version: ["v1.34.4-k3s1"]
 
     permissions:

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -45,7 +45,7 @@ uds run publish-image --set VERSION=<k3s-version>
 
 This repo intentionally stays n-1 on k3s (one minor version behind latest). The `allowedVersions: "<1.36"` constraint in `renovate.json` enforces this; update it manually when adopting a new minor version.
 
-All k3s references track the upstream `k3s-io/k3s` GitHub releases directly, so version bumps come in a **single PR** that updates `tasks.yaml`, `build-test.yaml`, and `zarf.yaml`'s `K3D_IMAGE` default together. CI passes because both the connected and airgap builds construct the custom image locally, with no GHCR pull during CI. After the PR merges, `publish-image.yaml` triggers and publishes the new image to GHCR.
+All k3s references track the upstream `rancher/k3s` Docker image directly, so version bumps come in a **single PR** that updates `tasks.yaml`, `build-test.yaml`, and `zarf.yaml`'s `K3D_IMAGE` default together. CI passes because both the connected and airgap builds construct the custom image locally, with no GHCR pull during CI. After the PR merges, `publish-image.yaml` triggers and publishes the new image to GHCR.
 
 The airgap package builds the custom k3s image locally during `zarf package create` using the version from `tasks.yaml`, so it has no GHCR dependency at package creation time.
 

--- a/renovate.json
+++ b/renovate.json
@@ -49,16 +49,5 @@
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
       "allowedVersions": "<1.36"
     }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)zarf\\.yaml$"],
-      "matchStrings": [
-        "# renovate-tag: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n(?<indent>\\s+)default: \"(?<prefix>[^:]+):(?<currentValue>[^\"]+)\""
-      ],
-      "versioningTemplate": "{{{versioning}}}",
-      "autoReplaceStringTemplate": "# renovate-tag: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n{{{indent}}}default: \"{{{prefix}}}:{{{newValue}}}\""
-    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "groupName": "support-deps",
       "commitMessageTopic": "support-deps",
       "matchPackageNames": [
-        "!k3s-io/k3s"
+        "!rancher/k3s"
       ]
     },
     {
@@ -32,20 +32,20 @@
       "groupName": "dev-stack",
       "commitMessageTopic": "dev-stack",
       "matchPackageNames": [
-        "!k3s-io/k3s",
+        "!rancher/k3s",
         "!defenseunicorns/uds-common"
       ]
     },
     {
       "matchPackageNames": [
-        "k3s-io/k3s",
+        "rancher/k3s",
         "cgr.dev/chainguard/wolfi-base"
       ],
       "groupName": "k3s",
       "commitMessageTopic": "k3s"
     },
     {
-      "matchPackageNames": ["k3s-io/k3s"],
+      "matchPackageNames": ["rancher/k3s"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
       "allowedVersions": "<1.36"
     }
@@ -58,7 +58,7 @@
         "# renovate-tag: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n(?<indent>\\s+)default: \"(?<prefix>[^:]+):(?<currentValue>[^\"]+)\""
       ],
       "versioningTemplate": "{{{versioning}}}",
-      "autoReplaceStringTemplate": "# renovate-tag: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n{{{indent}}}default: \"{{{prefix}}}:{{{replace '\\+k3s' '-k3s' newValue}}}\""
+      "autoReplaceStringTemplate": "# renovate-tag: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n{{{indent}}}default: \"{{{prefix}}}:{{{newValue}}}\""
     }
   ]
 }

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -3,7 +3,7 @@ includes:
 
 variables:
   - name: VERSION
-    # renovate: datasource=github-releases depName=k3s-io/k3s versioning=semver
+    # renovate: datasource=docker depName=rancher/k3s versioning=semver
     default: "v1.34.4-k3s1"
   - name: IMAGE_NAME
     default: "ghcr.io/defenseunicorns/uds-k3d/k3s"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    # renovate-tag: datasource=docker depName=rancher/k3s versioning=semver
+    # renovate: datasource=docker depName=rancher/k3s versioning=semver
     default: "ghcr.io/defenseunicorns/uds-k3d/k3s:v1.34.4-k3s1"
 
   - name: K3D_ULIMIT_NOFILE

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -17,7 +17,7 @@ variables:
 
   - name: K3D_IMAGE
     description: "K3d image to use"
-    # renovate-tag: datasource=github-releases depName=k3s-io/k3s versioning=semver
+    # renovate-tag: datasource=docker depName=rancher/k3s versioning=semver
     default: "ghcr.io/defenseunicorns/uds-k3d/k3s:v1.34.4-k3s1"
 
   - name: K3D_ULIMIT_NOFILE


### PR DESCRIPTION
## Description

- Switches k3s version tracking from datasource=github-releases depName=k3s-io/k3s to datasource=docker depName=rancher/k3s across all Renovate annotations (tasks.yaml, build-test.yaml, publish-image.yaml, zarf.yaml)
- Adds a customManagers entry in renovate.json to extract the version from the full image string in zarf.yaml so it can be tracked alongside the other k3s references in a single PR
- Adds versioning regex to handle the -k3sN Docker tag format and allowedVersions: "<1.36" to enforce the n-1 minor version policy
- Updates docs/CUSTOM-K3S-IMAGE.md to reflect the new tracking approach

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed