### PR TITLE
chore: update renovate to use custom manager for k3s1 deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,5 +49,16 @@
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
       "allowedVersions": "<1.36"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.github/workflows/.*\\.yaml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n(?<indent>\\s+)version: \\[\"(?<currentValue>[^\"]+)\"\\]"
+      ],
+      "versioningTemplate": "{{{versioning}}}",
+      "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n{{{indent}}}version: [\"{{{newValue}}}\"]"
+    }
   ]
 }


### PR DESCRIPTION
## Description

Switches k3s version tracking to rancher/k3s Docker Hub (tags use -k3s1 natively, no format conversion needed). Annotates all k3s version references so Renovate produces a single PR updating all files together. Groups rancher/k3s with cgr.dev/chainguard/wolfi-base in the k3s update group. Enforces n-1 minor version via allowedVersions: "<1.36".

Adds a custom regex manager for the GitHub Actions matrix version: ["..."] format, which the inherited uds-common manager cannot handle natively.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed