### PR TITLE
chore: fix k3s version not bumping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
     {
       "matchPackageNames": ["rancher/k3s"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
-      "allowedVersions": "<1.36"
+      "allowedVersions": "/^v1\\.3[0-5]\\.[0-9]/"
     }
   ],
   "customManagers": [
@@ -55,10 +55,9 @@
       "customType": "regex",
       "managerFilePatterns": ["/\\.github/workflows/.*\\.yaml$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n(?<indent>\\s+)version: \\[\"(?<currentValue>[^\"]+)\"\\]"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\n\\s+version: \\[\"(?<currentValue>[^\"]+)\"\\]"
       ],
-      "versioningTemplate": "{{{versioning}}}",
-      "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}} versioning={{{versioning}}}\n{{{indent}}}version: [\"{{{newValue}}}\"]"
+      "versioningTemplate": "{{{versioning}}}"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
     {
       "matchPackageNames": ["rancher/k3s"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
-      "allowedVersions": "/^v1\\.3[0-5]\\.[0-9]/"
+      "allowedVersions": "/^v1\\.35\\.\\d+/"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Description
- Replace `allowedVersions: "<1.36"` with regex form `/^v1\.3[0-5]\.[0-9]/` (still caps at 1.35.x; bump to `[0-6]` when 1.36 is allowed).
- Simplify the custom manager: drop `autoReplaceStringTemplate` and the `(?<indent>...)` capture, relying on default replacement behavior.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed