### PR TITLE
fix: avoid k3s ccm bootstrap configmap race

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -147,6 +147,8 @@ components:
                 --k3s-arg "--disable=metrics-server@server:*" \
                 --k3s-arg "--disable=servicelb@server:*" \
                 --k3s-arg "--disable=local-storage@server:*" \
+                --k3s-arg "--kube-cloud-controller-manager-arg=requestheader-client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt@server:*" \
+                --k3s-arg "--kube-cloud-controller-manager-arg=client-ca-file=/var/lib/rancher/k3s/server/tls/client-ca.crt@server:*" \
                 --image ${ZARF_VAR_K3D_IMAGE} \
                 ${ZARF_VAR_K3D_EXTRA_ARGS} \
                 ${NETWORK} \


### PR DESCRIPTION
## Description

Fixes a K3s cloud-controller-manager bootstrap race that can prevent local/CI k3d clusters from reaching CoreDNS readiness.

The failure presents as kube-dns/CoreDNS never becoming ready, but the root cause is K3s shutting down after the embedded cloud-controller-manager fails to read the `extension-apiserver-authentication` configmap during bootstrap:

```text
unable to load configmap based request-header-client-ca-file: configmaps "extension-apiserver-authentication" is forbidden: User "k3s-cloud-controller-manager" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
```

This change passes the CCM CA files directly:

- `requestheader-client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt`
- `client-ca-file=/var/lib/rancher/k3s/server/tls/client-ca.crt`

That removes the CCM startup dependency on the configmap lookup during the bootstrap window.

## Validation

- Reproduced the exact failure locally with the old image, without this fix:
  - image: `ghcr.io/defenseunicorns/uds-k3d/k3s:v1.35.3-k3s1`
  - result: failed on run 11 of 100
  - failure matched the CCM forbidden configmap error above

- Verified the fix with the same old image:
  - image: `ghcr.io/defenseunicorns/uds-k3d/k3s:v1.35.3-k3s1`
  - result: passed 100 cluster create/CoreDNS readiness loops

- Verified the fix with the current image:
  - image: `ghcr.io/defenseunicorns/uds-k3d/k3s:v1.35.4-k3s1`
  - result: passed 50 cluster create/CoreDNS readiness loops

- Ran package validation:
  - `uds zarf tools yq e '.' zarf.yaml`
  - `git diff --check`
  - `uds run default`
  - `uds run build-image`
  - `uds run deploy --no-progress`
  - `uds run validate --no-progress`

- Ran UDS Core regression on a cluster created by modified `uds-k3d`:
  - build/deploy/validate passed
  - `uds run -f tasks/test.yaml validate-packages --no-progress` passed

## Reviewer Repro

The local repro loop was equivalent to:

```bash
for i in $(seq 1 100); do
  name="uds-ccm-race-$i"
  k3d cluster delete "$name" >/dev/null 2>&1 || true

  k3d cluster create "$name" \
    --api-port "127.0.0.1:$((16550 + i))" \
    --image ghcr.io/defenseunicorns/uds-k3d/k3s:v1.35.3-k3s1 \
    --k3s-arg "--disable=traefik@server:*" \
    --k3s-arg "--disable=metrics-server@server:*" \
    --k3s-arg "--disable=servicelb@server:*" \
    --k3s-arg "--disable=local-storage@server:*"

  KUBECONFIG="$(k3d kubeconfig write "$name")" \
    kubectl -n kube-system wait --for=condition=Ready pod -l k8s-app=kube-dns --timeout=120s || {
      docker logs "k3d-$name-server-0" 2>&1 | grep -E "cloud-controller-manager exited|unable to load configmap|k3s-cloud-controller-manager"
      exit 1
    }

  docker logs "k3d-$name-server-0" 2>&1 | grep -Eq "cloud-controller-manager exited|unable to load configmap based request-header-client-ca-file" && {
    docker logs "k3d-$name-server-0" 2>&1 | grep -E "cloud-controller-manager exited|unable to load configmap|k3s-cloud-controller-manager"
    exit 1
  }

  k3d cluster delete "$name" >/dev/null
done
```

Before the fix, this reproduced the CCM bootstrap failure on run 11 with `v1.35.3-k3s1`.

After adding the two CCM CA-file args from this PR, the same loop passed 100 runs with `v1.35.3-k3s1` and 50 runs with `v1.35.4-k3s1`.

## Related Issue

Fixes Core-593

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed