### PR TITLE
fix: bundle metallb frr-k8s image for airgap deploys

### DIFF
--- a/airgap/uds-dev-stack/zarf.yaml
+++ b/airgap/uds-dev-stack/zarf.yaml
@@ -26,6 +26,8 @@ components:
         target: metallb-controller.tar
       - source: metallb-speaker.tar
         target: metallb-speaker.tar
+      - source: metallb-frr-k8s.tar
+        target: metallb-frr-k8s.tar
       - source: frr.tar
         target: frr.tar
       - source: minio.tar
@@ -54,8 +56,11 @@ components:
           # renovate: datasource=docker depName=quay.io/metallb/speaker
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/speaker:v0.16.1 metallb-speaker.tar
             description: Pull the metallb-speaker image
+          # renovate: datasource=docker depName=quay.io/metallb/frr-k8s
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/metallb/frr-k8s:v0.0.25 metallb-frr-k8s.tar
+            description: Pull the metallb-frr-k8s image
           # renovate: datasource=docker depName=quay.io/frrouting/frr
-          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/frrouting/frr:9.1.3 frr.tar
+          - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/frrouting/frr:10.4.3 frr.tar
             description: Pull the frr image
           # renovate: datasource=docker depName=quay.io/minio/minio versioning=regex:^RELEASE\.(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)T(?<build>\d+)-(?<revision>\d+)-\d+Z$
           - cmd: ./zarf tools registry pull --platform linux/"###ZARF_PKG_ARCH###" quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z minio.tar
@@ -73,10 +78,11 @@ components:
                 nginx.tar \
                 metallb-controller.tar \
                 metallb-speaker.tar \
+                metallb-frr-k8s.tar \
                 minio.tar \
                 minio-mc.tar \
                 frr.tar \
                 -c "${ZARF_VAR_CLUSTER_NAME}"
             description: Load the airgap images for uds-dev-stack into Docker
-          - cmd: rm pause.tar nginx.tar wolfi-base.tar busybox.tar local-path-provisioner.tar metallb-controller.tar metallb-speaker.tar minio.tar minio-mc.tar frr.tar
+          - cmd: rm pause.tar nginx.tar wolfi-base.tar busybox.tar local-path-provisioner.tar metallb-controller.tar metallb-speaker.tar metallb-frr-k8s.tar minio.tar minio-mc.tar frr.tar
             description: Cleanup the airgap image tars


### PR DESCRIPTION
## Description
Bundles missing metallb frr-k8s image for airgap deploys

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed