### PR TITLE
fix: seperated demo warning log from the airgap mode log

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -71,6 +71,17 @@ components:
         before:
           - cmd: k3d cluster delete "${ZARF_VAR_CLUSTER_NAME}"
             description: Destroy the cluster
+        after:
+          - cmd: |
+              echo ""
+              echo "########################################"
+              echo "#                                      #"
+              echo "#     THIS IS A DEMO PACKAGE ONLY      #"
+              echo "#   DO NOT DEPLOY THIS TO PRODUCTION   #"
+              echo "#                                      #"
+              echo "########################################"
+              echo ""
+            description: Warn the user that this package is not suitable for production
 
   - name: k3d-airgap-images
     required: true
@@ -93,7 +104,6 @@ components:
               echo "###################################################"
               echo "#                                                 #"
               echo "#      PACKAGE BEING DEPLOYED IN AIRGAP MODE      #"
-              echo "#    THIS IS NOT MEANT TO BE USED IN PRODUCTION   #"
               echo "#                                                 #"
               echo "###################################################"
               echo ""


### PR DESCRIPTION
## Description

Clarify logs so that it does not come across as us recommending users to not deploy in airgap mode to production. Additionally the do not deploy to production log now occurs even if the flavor is not airgap.

## Related Issue

Fixes CORE-616

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed