### PR TITLE
fix: add quotes to k3s image tag in workflows to fix renovate matching

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         # renovate: datasource=docker depName=rancher/k3s versioning=semver
-        version: [v1.35.5-k3s1]
+        version: ["v1.35.6-k3s1"]
         architecture: [amd64, arm64]
 
     steps:

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # renovate: datasource=docker depName=rancher/k3s versioning=semver
-        version: [v1.35.5-k3s1]
+        version: ["v1.35.6-k3s1"]
 
     permissions:
       contents: read

--- a/.yamllint
+++ b/.yamllint
@@ -31,7 +31,7 @@ rules:
   new-lines: enable
   octal-values: disable
   quoted-strings:
-    required: only-when-needed
+    required: false
     quote-type: double
   trailing-spaces: enable
   truthy:


### PR DESCRIPTION
## Description

Fixes renovate matching of k3s image in publish and test workflows which was broken by removal of `"`s around the tag in #352 . Also updates versions to latest version to match published image tag used by the package to fix errors caused by missing image when attempting to install the latest [release](https://github.com/defenseunicorns/uds-k3d/releases/tag/v0.20.2).

yamllint configuration docs here: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.quoted_strings

- `required` defines whether using quotes in string values is required (`true`, default) or not (`false`), or only allowed when really needed (`only-when-needed`).

## Related Issue

Fixes CORE-639

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed