### PR TITLE
chore: bump default k8s to 1.36

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         # renovate: datasource=docker depName=rancher/k3s versioning=semver
-        version: ["v1.35.8-k3s1"]
+        version: ["v1.36.4-k3s1"]
         architecture: [amd64, arm64]
 
     steps:

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -9,6 +9,8 @@ on:
       - main
     paths:
       - docker/**
+      - tasks.yaml
+      - zarf.yaml
       - .github/workflows/publish-image.yaml
   workflow_dispatch:
 
@@ -18,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # renovate: datasource=docker depName=rancher/k3s versioning=semver
-        version: ["v1.35.8-k3s1"]
+        version: ["v1.36.4-k3s1"]
 
     permissions:
       contents: read

--- a/docs/CUSTOM-K3S-IMAGE.md
+++ b/docs/CUSTOM-K3S-IMAGE.md
@@ -43,7 +43,7 @@ uds run publish-image --set VERSION=<k3s-version>
 
 ## Renovate Updates
 
-This repo intentionally stays n-1 on k3s (one minor version behind latest). The `allowedVersions: "<1.36"` constraint in `renovate.json` enforces this; update it manually when adopting a new minor version.
+This repo intentionally stays n-1 on k3s (one minor version behind latest). Renovate enforces this with the `allowedVersions` constraint in `renovate.json`; update that constraint manually when adopting a new minor version.
 
 All k3s references track the upstream `rancher/k3s` Docker image directly, so version bumps come in a **single PR** that updates `tasks.yaml`, `build-test.yaml`, and `zarf.yaml`'s `K3D_IMAGE` default together. CI passes because both the connected and airgap builds construct the custom image locally, with no GHCR pull during CI. After the PR merges, `publish-image.yaml` triggers and publishes the new image to GHCR.
 

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
     {
       "matchPackageNames": ["rancher/k3s"],
       "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)[+-]k3s(?<build>\\d+)$",
-      "allowedVersions": "/^v1\\.35\\.\\d+/"
+      "allowedVersions": "/^v1\\.36\\.\\d+/"
     }
   ],
   "customManagers": [

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -8,7 +8,7 @@ includes:
 variables:
   - name: VERSION
     # renovate: datasource=docker depName=rancher/k3s versioning=semver
-    default: v1.35.8-k3s1
+    default: v1.36.4-k3s1
   - name: IMAGE_NAME
     default: ghcr.io/defenseunicorns/uds-k3d/k3s
   - name: K3D_EXTRA_ARGS

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -21,7 +21,7 @@ variables:
   - name: K3D_IMAGE
     description: K3d image to use
     # renovate: datasource=docker depName=rancher/k3s versioning=semver
-    default: ghcr.io/defenseunicorns/uds-k3d/k3s:v1.35.8-k3s1
+    default: ghcr.io/defenseunicorns/uds-k3d/k3s:v1.36.4-k3s1
 
   - name: K3D_ULIMIT_NOFILE
     description: "Set ulimit for the number of files (nofile) to container runtime (Format: SOFT:HARD)"


### PR DESCRIPTION
## Description

Updates default k3s version to 1.36. This aligns with `N-1` testing workflow we have for UDS.  Currently 1.37 is available.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed