### PR TITLE
fix: add frr-k8s image to metalb values

### DIFF
--- a/values/metallb-values.yaml
+++ b/values/metallb-values.yaml
@@ -13,6 +13,10 @@ speaker:
     tag: v0.16.1
 frr-k8s:
   frrk8s:
+    image:
+      repository: quay.io/metallb/frr-k8s
+      # renovate: datasource=docker depName=quay.io/metallb/frr-k8s
+      tag: v0.0.25
     frr:
       image:
         repository: quay.io/frrouting/frr


### PR DESCRIPTION
## Description

Renovate is missing a bump of images in our metallb config.  This is resulting in failing CI in: https://github.com/defenseunicorns/uds-k3d/pull/375 because there is an image mismatch. Making this image explicit and tracked by renovate will fix these bumps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-k3d/blob/main/CONTRIBUTING.md) followed